### PR TITLE
feat: add power ETA and OSM route map

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/DATABASE_IMPLEMENTATION.md
+++ b/DATABASE_IMPLEMENTATION.md
@@ -1,0 +1,201 @@
+# Database Implementation Summary
+
+## Overview
+Successfully implemented database storage for routes and analysis results in `api/app/services/analyze.py`. The implementation uses PostgreSQL with SQLAlchemy ORM and maintains an in-memory cache for performance.
+
+## Changes Made
+
+### 1. Added Database Imports
+- Added imports for SQLAlchemy models: `RouteDB`, `RouteSampleDB`, `ForecastResultDB`, `SegmentWindDB`, `SummaryDB`
+- Added `async_session_maker` for database session management
+- Added `select`, `and_` from SQLAlchemy for queries
+- Added `IntegrityError` for handling duplicate entries
+- Added `json` module for serializing bbox data
+
+### 2. Updated `get_route()` Method
+**Before:** Only checked in-memory storage
+**After:**
+- First checks in-memory cache for performance
+- Falls back to database query if not cached
+- Converts database model to domain model (Pydantic)
+- Caches the result in memory for subsequent requests
+- Returns `None` if route not found
+
+### 3. Implemented `get_route_results()` Method
+**Before:** Placeholder that returned empty list
+**After:**
+- Queries database for recent forecast results for a given route
+- Orders by creation date (newest first)
+- Supports pagination with limit parameter
+- Returns list of dictionaries with result metadata
+- Gracefully handles database errors
+
+### 4. Updated `_load_route_points()` Method
+**Before:** Only checked in-memory storage and demo route
+**After:**
+- First checks in-memory cache
+- Attempts to load demo route if requested
+- Falls back to database query for route samples
+- Orders samples by sequence number
+- Converts `RouteSampleDB` records to `RoutePoint` objects
+- Caches loaded points in memory
+
+### 5. Implemented `_store_route()` Method
+**Before:** Only stored in memory
+**After:**
+- Creates `RouteDB` record with route metadata
+- Creates `RouteSampleDB` records for each route point
+- Calculates `eta_offset_s` using default cycling speed (25 km/h)
+- Handles duplicate entries gracefully (catches `IntegrityError`)
+- Stores bbox as JSON string
+- Commits transaction atomically
+- Falls back to memory-only storage if database unavailable
+- Maintains in-memory cache for performance
+
+### 6. Implemented `_store_analysis_result()` Method
+**Before:** Placeholder that didn't store anything
+**After:**
+- Creates `ForecastResultDB` record with analysis metadata
+- Creates `SegmentWindDB` records for each wind segment
+- Creates `SummaryDB` record with aggregated statistics
+- Converts `WindClass` enum to string value for database
+- Commits all records in a single transaction
+- Gracefully handles storage failures without breaking analysis
+- Logs successful storage with segment count
+
+## Architecture Pattern
+
+### Hybrid Storage Strategy
+The implementation uses a hybrid caching strategy:
+
+1. **Write-through Cache:**
+   - Data is written to both database and memory cache
+   - Database is source of truth
+   - Memory cache improves read performance
+
+2. **Lazy Loading:**
+   - Data is loaded from database on cache miss
+   - Subsequent reads served from cache
+   - Reduces database load
+
+3. **Graceful Degradation:**
+   - If database is unavailable, falls back to memory-only
+   - Logs warnings but continues operation
+   - Ensures application remains functional
+
+### Data Flow
+
+#### Route Creation:
+```
+GPX Upload → Process Route → Create Route Model →
+→ Store in Database (routes + route_samples tables) →
+→ Cache in Memory → Return Route
+```
+
+#### Route Analysis:
+```
+Analysis Request → Load Route Points (DB/Cache) →
+→ Generate Forecast → Fetch Wind Data →
+→ Process Segments → Generate Summary →
+→ Store Results (forecast_results + segment_wind + summaries tables) →
+→ Return Analysis
+```
+
+#### Route Retrieval:
+```
+Get Route Request → Check Memory Cache →
+→ (Cache Miss) Query Database →
+→ Cache Result → Return Route
+```
+
+## Database Schema Usage
+
+### Tables Written To:
+1. **routes** - Route metadata (id, name, bbox, length, etc.)
+2. **route_samples** - Preprocessed route points with calculated metrics
+3. **forecast_results** - Analysis result metadata
+4. **segment_wind** - Wind conditions for each route segment
+5. **summaries** - Aggregated analysis statistics
+
+### Key Fields:
+- `bbox`: Stored as JSON string (serialized list)
+- `wind_class`: Stored as string enum value ('head', 'cross', 'tail')
+- `eta_offset_s`: Calculated using default speed of 25 km/h
+- `confidence`: Float between 0.0 and 1.0
+
+## Testing Recommendations
+
+### Manual Testing:
+1. Upload a GPX file and verify route is stored in database
+2. Run an analysis and verify results are persisted
+3. Restart the API server and verify data persists
+4. Check database tables using SQL client
+
+### SQL Queries for Verification:
+```sql
+-- Check routes
+SELECT id, name, length_km, created_at FROM routes;
+
+-- Check route samples for a specific route
+SELECT route_id, seq, lat, lon, dist_m
+FROM route_samples
+WHERE route_id = 'your-route-id'
+ORDER BY seq
+LIMIT 10;
+
+-- Check forecast results
+SELECT id, route_id, depart_time, provider, status, created_at
+FROM forecast_results
+ORDER BY created_at DESC;
+
+-- Check wind segments for a result
+SELECT result_id, seq, wind_class, wind_ms1p5m, yaw_deg
+FROM segment_wind
+WHERE result_id = 'your-result-id'
+ORDER BY seq
+LIMIT 10;
+
+-- Check summaries
+SELECT result_id, head_pct, tail_pct, cross_pct, longest_head_km
+FROM summaries;
+```
+
+### Database Connection:
+```bash
+# From root directory
+docker-compose up -d postgres
+
+# Connect to database
+docker exec -it <postgres-container-id> psql -U postgres -d against_wind
+```
+
+## Migration Status
+The implementation uses the existing schema defined in:
+- `api/migrations/001_initial_schema.sql`
+
+No new migrations are required as all necessary tables and columns already exist.
+
+## Next Steps
+
+### Potential Improvements:
+1. **Add database connection pooling configuration**
+2. **Implement result retrieval with segments and summary**
+3. **Add user_id support for multi-tenant usage**
+4. **Implement soft delete for routes**
+5. **Add database indexes optimization**
+6. **Implement cache invalidation strategy**
+7. **Add database query performance monitoring**
+8. **Implement batch operations for large datasets**
+
+### Performance Optimization:
+1. Consider using Redis for distributed caching
+2. Implement connection pooling with optimal pool size
+3. Add database query logging for slow queries
+4. Consider read replicas for scaling reads
+5. Implement pagination for large result sets
+
+## Notes
+- In-memory cache is still maintained for backwards compatibility
+- Demo route loading still works as before
+- All database operations are async for non-blocking I/O
+- Error handling ensures application resilience

--- a/api/alembic/versions/20260512_add_route_sample_elevation.py
+++ b/api/alembic/versions/20260512_add_route_sample_elevation.py
@@ -1,0 +1,27 @@
+"""Add elevation and grade to route samples.
+
+Revision ID: 20260512_elevation_grade
+Revises:
+Create Date: 2026-05-12
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260512_elevation_grade"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("route_samples", sa.Column("elevation_m", sa.Float(), nullable=True))
+    op.add_column("route_samples", sa.Column("grade_pct", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("route_samples", "grade_pct")
+    op.drop_column("route_samples", "elevation_m")

--- a/api/app/api/routes.py
+++ b/api/app/api/routes.py
@@ -1,11 +1,16 @@
 from fastapi import APIRouter, HTTPException, UploadFile, File, Query
 from fastapi.responses import StreamingResponse
-from typing import Optional
+from typing import Literal, Optional
 from datetime import datetime
 import json
 import asyncio
 import uuid
 from api.app.domain.models import Route, AnalysisRequest, ErrorEvent
+from api.app.domain.time_estimation import (
+    RiderPowerProfile,
+    estimate_route_timing,
+    route_elevation_stats,
+)
 from api.app.services.analyze import AnalysisService
 import logging
 
@@ -85,18 +90,21 @@ async def get_route_metadata(route_id: str):
                 end_time = max(p.timestamp for p in timestamped_points)
 
         total_distance_km = route_points[-1].distance_m / 1000.0 if route_points else 0
+        elevation_stats = route_elevation_stats(route_points)
+        default_timing = estimate_route_timing(route_points, RiderPowerProfile())
 
         return {
             "route_id": route_id,
             "total_distance_km": total_distance_km,
             "total_points": len(route_points),
+            **elevation_stats,
             "has_timestamps": has_timestamps,
             "timestamp_coverage": timestamp_coverage,
             "start_time": start_time,
             "end_time": end_time,
-            "estimated_duration_hours": total_distance_km / 25.0
-            if total_distance_km > 0
-            else 0,  # Default 25 km/h
+            "estimated_duration_hours": default_timing.total_duration_s / 3600.0,
+            "eta_model": default_timing.model,
+            "eta_warnings": default_timing.warnings,
         }
 
     except HTTPException:
@@ -149,10 +157,20 @@ async def analyze_route(
     route_id: str = Query(..., description="Route ID to analyze"),
     depart: str = Query(..., description="Departure time in ISO format"),
     provider: str = Query("open-meteo", description="Forecast provider"),
-    speed_profile: str = Query("preset", description="Speed profile"),
-    use_gpx_timestamps: bool = Query(False, description="Use timestamps from GPX file"),
+    timing_mode: Literal["power", "manual_duration", "gpx_timestamps"] = Query(
+        "power", description="Timing mode"
+    ),
     estimated_duration_hours: Optional[float] = Query(
         None, description="Estimated duration for routes without timestamps"
+    ),
+    ftp_w_per_kg: Optional[float] = Query(
+        None, gt=0, le=10, description="Rider FTP in watts per kilogram"
+    ),
+    rider_weight_kg: Optional[float] = Query(
+        None, gt=0, le=250, description="Rider weight in kilograms"
+    ),
+    bike_weight_kg: Optional[float] = Query(
+        None, ge=0, le=80, description="Bike and kit weight in kilograms"
     ),
     use_historical_mode: bool = Query(
         False,
@@ -169,9 +187,11 @@ async def analyze_route(
             route_id=route_id,
             depart_time=depart_time,
             provider=provider,
-            speed_profile=speed_profile,
-            use_gpx_timestamps=use_gpx_timestamps,
+            timing_mode=timing_mode,
             estimated_duration_hours=estimated_duration_hours,
+            ftp_w_per_kg=ftp_w_per_kg,
+            rider_weight_kg=rider_weight_kg,
+            bike_weight_kg=bike_weight_kg,
             use_historical_mode=use_historical_mode,
         )
 

--- a/api/app/domain/models.py
+++ b/api/app/domain/models.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Protocol, Optional, Dict, Any, List
+from typing import AsyncIterator, Protocol, Optional, Dict, Any, List, Literal
 from datetime import datetime
 from pydantic import BaseModel, Field
 from enum import Enum
@@ -103,12 +103,12 @@ class AnalysisRequest(BaseModel):
     route_id: str
     depart_time: datetime
     provider: str = "open-meteo"
-    speed_profile: str = "preset"
-    use_gpx_timestamps: bool = False  # Use timestamps from GPX file if available
-    estimated_duration_hours: Optional[float] = None  # For routes without timestamps
-    use_historical_mode: bool = (
-        False  # Use GPX start time as actual departure for historical analysis
-    )
+    timing_mode: Literal["power", "manual_duration", "gpx_timestamps"] = "power"
+    estimated_duration_hours: Optional[float] = Field(None, gt=0, le=48)
+    ftp_w_per_kg: Optional[float] = Field(None, gt=0, le=10)
+    rider_weight_kg: Optional[float] = Field(None, gt=0, le=250)
+    bike_weight_kg: Optional[float] = Field(None, ge=0, le=80)
+    use_historical_mode: bool = False
 
 
 class ForecastResult(BaseModel):

--- a/api/app/domain/time_estimation.py
+++ b/api/app/domain/time_estimation.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import math
+from typing import Iterable, List, Optional, Sequence
+
+from api.app.domain.models import ForecastPoint, WindSample
+from api.app.geo.gpx import RoutePoint
+
+
+@dataclass(frozen=True)
+class RiderPowerProfile:
+    ftp_w_per_kg: float = 2.5
+    rider_weight_kg: float = 75.0
+    bike_weight_kg: float = 10.0
+    cda: float = 0.32
+    crr: float = 0.005
+    air_density_kg_m3: float = 1.225
+    min_speed_kmh: float = 4.0
+    max_flat_speed_kmh: float = 55.0
+    max_descent_speed_kmh: float = 60.0
+
+    @property
+    def rider_power_w(self) -> float:
+        return self.ftp_w_per_kg * self.rider_weight_kg
+
+    @property
+    def total_mass_kg(self) -> float:
+        return self.rider_weight_kg + self.bike_weight_kg
+
+
+@dataclass(frozen=True)
+class RouteTimingEstimate:
+    eta_offsets_s: List[float]
+    total_duration_s: float
+    model: str
+    warnings: List[str]
+
+
+def estimate_route_timing(
+    route_points: Sequence[RoutePoint],
+    profile: RiderPowerProfile,
+    wind_samples: Optional[Sequence[WindSample]] = None,
+    reference_points: Optional[Sequence[ForecastPoint]] = None,
+) -> RouteTimingEstimate:
+    """Estimate per-point ETA using a constant rider power model."""
+    if not route_points:
+        return RouteTimingEstimate([], 0.0, "power", [])
+
+    warnings = _validate_profile(profile)
+    eta_offsets = [0.0]
+    has_elevation = any(point.elevation is not None for point in route_points)
+    has_wind = bool(wind_samples)
+
+    if not has_elevation:
+        warnings.append("Route has no elevation data; assuming flat terrain.")
+
+    for i in range(1, len(route_points)):
+        prev_point = route_points[i - 1]
+        point = route_points[i]
+        distance_m = max(0.0, point.distance_m - prev_point.distance_m)
+        if distance_m <= 0:
+            eta_offsets.append(eta_offsets[-1])
+            continue
+
+        grade = _segment_grade(prev_point, point)
+        bearing = (
+            point.bearing_deg
+            if point.bearing_deg is not None
+            else prev_point.bearing_deg
+        )
+        bearing = bearing if bearing is not None else 0.0
+        wind_along_ms = _segment_wind_along_route(
+            point=point,
+            bearing_deg=bearing,
+            point_time=reference_points[i].time_utc
+            if reference_points and i < len(reference_points)
+            else None,
+            wind_samples=wind_samples,
+        )
+        speed_ms = solve_ground_speed_ms(profile, grade, wind_along_ms)
+        eta_offsets.append(eta_offsets[-1] + distance_m / speed_ms)
+
+    model = "power_with_wind" if has_wind else "power"
+    return RouteTimingEstimate(
+        eta_offsets_s=eta_offsets,
+        total_duration_s=eta_offsets[-1],
+        model=model,
+        warnings=warnings,
+    )
+
+
+def build_forecast_points_from_offsets(
+    route_points: Sequence[RoutePoint],
+    depart_time: datetime,
+    eta_offsets_s: Sequence[float],
+) -> List[ForecastPoint]:
+    return [
+        ForecastPoint(
+            lat=point.lat,
+            lon=point.lon,
+            time_utc=depart_time + timedelta(seconds=eta_offsets_s[i]),
+        )
+        for i, point in enumerate(route_points)
+    ]
+
+
+def route_elevation_stats(route_points: Sequence[RoutePoint]) -> dict:
+    total_ascent_m = 0.0
+    total_descent_m = 0.0
+    previous_elevation = None
+
+    for point in route_points:
+        if point.elevation is None:
+            continue
+        if previous_elevation is not None:
+            delta_m = point.elevation - previous_elevation
+            if delta_m > 0:
+                total_ascent_m += delta_m
+            elif delta_m < 0:
+                total_descent_m += abs(delta_m)
+        previous_elevation = point.elevation
+
+    elevation_count = sum(1 for point in route_points if point.elevation is not None)
+    return {
+        "has_elevation": elevation_count > 0,
+        "elevation_coverage": elevation_count / len(route_points)
+        if route_points
+        else 0.0,
+        "total_ascent_m": total_ascent_m,
+        "total_descent_m": total_descent_m,
+    }
+
+
+def solve_ground_speed_ms(
+    profile: RiderPowerProfile,
+    grade: float,
+    wind_along_ms: float = 0.0,
+) -> float:
+    min_speed_ms = profile.min_speed_kmh / 3.6
+    max_speed_kmh = (
+        profile.max_descent_speed_kmh if grade < -0.01 else profile.max_flat_speed_kmh
+    )
+    max_speed_ms = max_speed_kmh / 3.6
+    target_power = profile.rider_power_w
+
+    if _required_power_w(min_speed_ms, grade, wind_along_ms, profile) >= target_power:
+        return min_speed_ms
+    if _required_power_w(max_speed_ms, grade, wind_along_ms, profile) <= target_power:
+        return max_speed_ms
+
+    low = min_speed_ms
+    high = max_speed_ms
+    for _ in range(48):
+        mid = (low + high) / 2.0
+        if _required_power_w(mid, grade, wind_along_ms, profile) < target_power:
+            low = mid
+        else:
+            high = mid
+    return (low + high) / 2.0
+
+
+def _required_power_w(
+    ground_speed_ms: float,
+    grade: float,
+    wind_along_ms: float,
+    profile: RiderPowerProfile,
+) -> float:
+    mass = profile.total_mass_kg
+    gravity = 9.80665
+    air_speed_ms = max(0.0, ground_speed_ms - wind_along_ms)
+    gravity_power = mass * gravity * grade * ground_speed_ms
+    rolling_power = profile.crr * mass * gravity * ground_speed_ms
+    aero_power = (
+        0.5
+        * profile.air_density_kg_m3
+        * profile.cda
+        * (air_speed_ms**2)
+        * ground_speed_ms
+    )
+    return gravity_power + rolling_power + aero_power
+
+
+def _segment_grade(prev_point: RoutePoint, point: RoutePoint) -> float:
+    if point.grade_pct is not None:
+        return point.grade_pct / 100.0
+
+    distance_m = point.distance_m - prev_point.distance_m
+    if distance_m <= 0 or prev_point.elevation is None or point.elevation is None:
+        return 0.0
+    return max(-0.25, min(0.25, (point.elevation - prev_point.elevation) / distance_m))
+
+
+def _segment_wind_along_route(
+    point: RoutePoint,
+    bearing_deg: float,
+    point_time: Optional[datetime],
+    wind_samples: Optional[Sequence[WindSample]],
+) -> float:
+    if not wind_samples:
+        return 0.0
+
+    sample = _find_closest_wind_sample(point, point_time, wind_samples)
+    if sample is None:
+        return 0.0
+
+    bearing_rad = math.radians(bearing_deg)
+    east_unit = math.sin(bearing_rad)
+    north_unit = math.cos(bearing_rad)
+    return sample.u_ms * east_unit + sample.v_ms * north_unit
+
+
+def _find_closest_wind_sample(
+    point: RoutePoint,
+    point_time: Optional[datetime],
+    wind_samples: Iterable[WindSample],
+) -> Optional[WindSample]:
+    candidates = []
+    for sample in wind_samples:
+        lat = sample.meta.get("lat")
+        lon = sample.meta.get("lon")
+        if lat is None or lon is None:
+            continue
+
+        location_delta = abs(lat - point.lat) + abs(lon - point.lon)
+        if location_delta > 0.2:
+            continue
+
+        time_delta = 0.0
+        if point_time is not None:
+            time_delta = abs((sample.valid_from - point_time).total_seconds())
+            if time_delta > 7200:
+                continue
+
+        candidates.append((location_delta, time_delta, sample))
+
+    if not candidates:
+        return None
+
+    _, _, sample = min(candidates, key=lambda item: (item[0], item[1]))
+    return sample
+
+
+def _validate_profile(profile: RiderPowerProfile) -> List[str]:
+    warnings = []
+    if profile.ftp_w_per_kg <= 0:
+        warnings.append(
+            "FTP/kg must be positive; using default profile is recommended."
+        )
+    if profile.rider_weight_kg <= 0 or profile.bike_weight_kg < 0:
+        warnings.append(
+            "Rider and bike weight must be positive; using default profile is recommended."
+        )
+    return warnings

--- a/api/app/geo/gpx.py
+++ b/api/app/geo/gpx.py
@@ -423,6 +423,7 @@ class GPXProcessor:
                     elevation=elevation,
                     distance_m=distance,
                     bearing_deg=bearing,
+                    grade_pct=p1.grade_pct,
                     timestamp=timestamp,
                 )
 

--- a/api/app/services/analyze.py
+++ b/api/app/services/analyze.py
@@ -19,6 +19,11 @@ from api.app.domain.models import (
     PartialResultEvent,
     WindClass,
 )
+from api.app.domain.time_estimation import (
+    RiderPowerProfile,
+    build_forecast_points_from_offsets,
+    estimate_route_timing,
+)
 from api.app.geo.gpx import GPXProcessor, RoutePoint
 from api.app.geo.interp import WindInterpolator
 from api.app.providers.open_meteo import get_provider
@@ -44,6 +49,7 @@ _analysis_cache: Dict[str, dict] = {}
 
 # Fixed demo route ID used by the UI
 DEMO_ROUTE_ID = "demo-glossop-sheffield"
+WIND_REFETCH_THRESHOLD_SECONDS = 900
 
 
 class AnalysisService:
@@ -178,9 +184,7 @@ class AnalysisService:
         """Analyze route and stream progress updates."""
         try:
             # Attempt to serve from cache first
-            cache_key = self._cache_key(
-                request.route_id, request.provider, request.depart_time
-            )
+            cache_key = self._cache_key(request)
             if cache_key in _analysis_cache:
                 cached = _analysis_cache[cache_key]
                 yield ProgressEvent(
@@ -215,12 +219,8 @@ class AnalysisService:
                 }
             )
 
-            forecast_points = self._generate_forecast_points(
-                route_points,
-                request.depart_time,
-                request.use_gpx_timestamps,
-                request.estimated_duration_hours,
-                request.use_historical_mode,
+            forecast_points, timing_estimate = self._build_initial_timing(
+                route_points, request
             )
 
             # Step 3: Fetch wind data
@@ -345,6 +345,28 @@ class AnalysisService:
                         "No wind data available for the requested time and location"
                     )
 
+            if request.timing_mode == "power":
+                yield ProgressEvent(
+                    data={
+                        "stage": "refining_eta",
+                        "progress": 0.45,
+                        "message": "Refining ETA with elevation and wind...",
+                    }
+                )
+                (
+                    forecast_points,
+                    wind_samples,
+                    timing_estimate,
+                ) = await self._refine_power_timing_with_wind(
+                    provider,
+                    route_points,
+                    request,
+                    forecast_points,
+                    wind_samples,
+                    timing_estimate,
+                )
+                segments = []
+
             logger.info(
                 f"Retrieved {len(wind_samples)} wind samples from {request.provider}"
             )
@@ -402,6 +424,7 @@ class AnalysisService:
                 "segments": [seg.model_dump() for seg in segments],
                 "summary": summary.model_dump(),
                 "map_style_url": self._generate_map_style_url(segments),
+                "timing": timing_estimate,
             }
             # Cache the completed payload
             _analysis_cache[cache_key] = payload
@@ -421,134 +444,234 @@ class AnalysisService:
             logger.error(f"Analysis failed: {e}")
             yield ErrorEvent(data={"error": "analysis_failed", "message": str(e)})
 
-    def _generate_forecast_points(
+    def _build_initial_timing(
+        self, route_points: List[RoutePoint], request: AnalysisRequest
+    ) -> tuple[List[ForecastPoint], dict]:
+        if request.timing_mode == "gpx_timestamps":
+            forecast_points = self._forecast_points_from_gpx_timestamps(
+                route_points, request.depart_time, request.use_historical_mode
+            )
+            model = "gpx_historical" if request.use_historical_mode else "gpx_shifted"
+            return forecast_points, self._build_timing_payload(
+                forecast_points, request.depart_time, model, []
+            )
+
+        if request.timing_mode == "manual_duration":
+            if request.estimated_duration_hours is None:
+                raise ValueError(
+                    "estimated_duration_hours is required for manual_duration timing"
+                )
+            forecast_points = self._forecast_points_from_duration(
+                route_points, request.depart_time, request.estimated_duration_hours
+            )
+            return forecast_points, self._build_timing_payload(
+                forecast_points, request.depart_time, "manual_duration", []
+            )
+
+        return self._generate_power_forecast_points(
+            route_points, request.depart_time, request
+        )
+
+    def _forecast_points_from_gpx_timestamps(
         self,
         route_points: List[RoutePoint],
         depart_time: datetime,
-        use_gpx_timestamps: bool = False,
-        estimated_duration_hours: Optional[float] = None,
-        use_historical_mode: bool = False,
+        use_historical_mode: bool,
     ) -> List[ForecastPoint]:
-        """Generate forecast points from route points with different timing modes."""
-        forecast_points = []
-
-        if use_historical_mode and any(p.timestamp for p in route_points):
-            # Mode 1: Historical analysis - use GPX timestamps as-is for historical wind data
-            timestamped_points = [p for p in route_points if p.timestamp is not None]
-            if timestamped_points:
-                logger.info(
-                    "Using historical mode - GPX timestamps used as actual times for historical wind analysis"
-                )
-
-                for point in route_points:
-                    if point.timestamp is not None:
-                        # Use GPX timestamp directly for historical analysis
-                        point_time = point.timestamp
-                    else:
-                        # Fallback: interpolate based on surrounding timestamped points
-                        # Find nearest timestamped points before and after
-                        before_points = [
-                            p
-                            for p in timestamped_points
-                            if p.distance_m <= point.distance_m
-                        ]
-                        after_points = [
-                            p
-                            for p in timestamped_points
-                            if p.distance_m > point.distance_m
-                        ]
-
-                        if before_points and after_points:
-                            before_point = max(
-                                before_points, key=lambda p: p.distance_m
-                            )
-                            after_point = min(after_points, key=lambda p: p.distance_m)
-
-                            # Linear interpolation between timestamps
-                            distance_ratio = (
-                                point.distance_m - before_point.distance_m
-                            ) / (after_point.distance_m - before_point.distance_m)
-                            time_diff = (
-                                after_point.timestamp - before_point.timestamp
-                            ).total_seconds()
-                            interpolated_seconds = time_diff * distance_ratio
-                            point_time = before_point.timestamp + timedelta(
-                                seconds=interpolated_seconds
-                            )
-                        elif before_points:
-                            # Use last known timestamp
-                            point_time = max(
-                                before_points, key=lambda p: p.distance_m
-                            ).timestamp
-                        elif after_points:
-                            # Use first known timestamp
-                            point_time = min(
-                                after_points, key=lambda p: p.distance_m
-                            ).timestamp
-                        else:
-                            # Fallback to distance-based calculation from GPX start
-                            gpx_start_time = min(
-                                p.timestamp for p in timestamped_points
-                            )
-                            avg_speed_kmh = 25.0
-                            eta_hours = point.distance_m / 1000.0 / avg_speed_kmh
-                            point_time = gpx_start_time + timedelta(hours=eta_hours)
-
-                    forecast_points.append(
-                        ForecastPoint(lat=point.lat, lon=point.lon, time_utc=point_time)
-                    )
-        elif use_gpx_timestamps and any(p.timestamp for p in route_points):
-            # Mode 2: Use GPX timestamps with offset from departure time
-            timestamped_points = [p for p in route_points if p.timestamp is not None]
-            if timestamped_points:
-                # Calculate offset between desired departure time and GPX start time
-                gpx_start_time = min(p.timestamp for p in timestamped_points)
-                time_offset = depart_time - gpx_start_time
-
-                for point in route_points:
-                    if point.timestamp is not None:
-                        # Use GPX timestamp with offset
-                        point_time = point.timestamp + time_offset
-                    else:
-                        # Fallback to distance-based calculation for points without timestamps
-                        avg_speed_kmh = 25.0
-                        eta_hours = point.distance_m / 1000.0 / avg_speed_kmh
-                        point_time = depart_time + timedelta(hours=eta_hours)
-
-                    forecast_points.append(
-                        ForecastPoint(lat=point.lat, lon=point.lon, time_utc=point_time)
-                    )
-        elif estimated_duration_hours is not None:
-            # Mode 2: Use estimated duration to distribute time across route
-            total_distance_km = (
-                route_points[-1].distance_m / 1000.0 if route_points else 0
+        timestamped_points = [
+            point for point in route_points if point.timestamp is not None
+        ]
+        if not timestamped_points:
+            raise ValueError(
+                "GPX timestamp timing was requested, but the route has no timestamps"
             )
 
-            for point in route_points:
-                # Calculate time based on distance ratio and estimated duration
-                distance_ratio = (
-                    point.distance_m / (total_distance_km * 1000.0)
-                    if total_distance_km > 0
+        gpx_start_time = min(point.timestamp for point in timestamped_points)
+        time_offset = (
+            timedelta(0) if use_historical_mode else depart_time - gpx_start_time
+        )
+
+        return [
+            ForecastPoint(
+                lat=point.lat,
+                lon=point.lon,
+                time_utc=self._timestamp_for_route_point(point, timestamped_points)
+                + time_offset,
+            )
+            for point in route_points
+        ]
+
+    def _timestamp_for_route_point(
+        self, point: RoutePoint, timestamped_points: List[RoutePoint]
+    ) -> datetime:
+        if point.timestamp is not None:
+            return point.timestamp
+
+        before_points = [
+            candidate
+            for candidate in timestamped_points
+            if candidate.distance_m <= point.distance_m
+        ]
+        after_points = [
+            candidate
+            for candidate in timestamped_points
+            if candidate.distance_m > point.distance_m
+        ]
+
+        if before_points and after_points:
+            before_point = max(
+                before_points, key=lambda candidate: candidate.distance_m
+            )
+            after_point = min(after_points, key=lambda candidate: candidate.distance_m)
+            distance_delta = after_point.distance_m - before_point.distance_m
+            if distance_delta <= 0:
+                return before_point.timestamp
+            distance_ratio = (
+                point.distance_m - before_point.distance_m
+            ) / distance_delta
+            time_delta_s = (
+                after_point.timestamp - before_point.timestamp
+            ).total_seconds()
+            return before_point.timestamp + timedelta(
+                seconds=time_delta_s * distance_ratio
+            )
+
+        if before_points:
+            return max(
+                before_points, key=lambda candidate: candidate.distance_m
+            ).timestamp
+
+        return min(after_points, key=lambda candidate: candidate.distance_m).timestamp
+
+    def _forecast_points_from_duration(
+        self,
+        route_points: List[RoutePoint],
+        depart_time: datetime,
+        duration_hours: float,
+    ) -> List[ForecastPoint]:
+        total_distance_m = route_points[-1].distance_m if route_points else 0.0
+        duration_s = duration_hours * 3600.0
+
+        return [
+            ForecastPoint(
+                lat=point.lat,
+                lon=point.lon,
+                time_utc=depart_time
+                + timedelta(
+                    seconds=duration_s * (point.distance_m / total_distance_m)
+                    if total_distance_m > 0
                     else 0
-                )
-                eta_hours = distance_ratio * estimated_duration_hours
-                point_time = depart_time + timedelta(hours=eta_hours)
+                ),
+            )
+            for point in route_points
+        ]
 
-                forecast_points.append(
-                    ForecastPoint(lat=point.lat, lon=point.lon, time_utc=point_time)
-                )
-        else:
-            # Mode 3: Default constant speed calculation
-            for point in route_points:
-                avg_speed_kmh = 25.0  # Average cycling speed
-                eta_hours = point.distance_m / 1000.0 / avg_speed_kmh
-                point_time = depart_time + timedelta(hours=eta_hours)
+    def _generate_power_forecast_points(
+        self,
+        route_points: List[RoutePoint],
+        depart_time: datetime,
+        request: AnalysisRequest,
+        wind_samples: Optional[List] = None,
+        reference_points: Optional[List[ForecastPoint]] = None,
+    ) -> tuple[List[ForecastPoint], dict]:
+        profile = self._rider_power_profile(request)
+        estimate = estimate_route_timing(
+            route_points,
+            profile,
+            wind_samples=wind_samples,
+            reference_points=reference_points,
+        )
+        forecast_points = build_forecast_points_from_offsets(
+            route_points, depart_time, estimate.eta_offsets_s
+        )
+        return forecast_points, self._build_timing_payload(
+            forecast_points, depart_time, estimate.model, estimate.warnings
+        )
 
-                forecast_points.append(
-                    ForecastPoint(lat=point.lat, lon=point.lon, time_utc=point_time)
-                )
+    async def _refine_power_timing_with_wind(
+        self,
+        provider,
+        route_points: List[RoutePoint],
+        request: AnalysisRequest,
+        forecast_points: List[ForecastPoint],
+        wind_samples: List,
+        timing_estimate: dict,
+    ) -> tuple[List[ForecastPoint], List, dict]:
+        refined_points, refined_timing = self._generate_power_forecast_points(
+            route_points,
+            request.depart_time,
+            request,
+            wind_samples=wind_samples,
+            reference_points=forecast_points,
+        )
 
-        return forecast_points
+        if not self._forecast_points_shifted(forecast_points, refined_points):
+            return refined_points, wind_samples, refined_timing
+
+        try:
+            refined_wind_samples = await provider.batch_wind(refined_points)
+        except Exception as e:
+            logger.warning(
+                "Wind-aware ETA refetch failed, using initial wind samples: %s", e
+            )
+            return forecast_points, wind_samples, timing_estimate
+
+        if not refined_wind_samples:
+            return forecast_points, wind_samples, timing_estimate
+
+        return refined_points, refined_wind_samples, refined_timing
+
+    def _rider_power_profile(self, request: AnalysisRequest) -> RiderPowerProfile:
+        return RiderPowerProfile(
+            ftp_w_per_kg=request.ftp_w_per_kg or RiderPowerProfile.ftp_w_per_kg,
+            rider_weight_kg=request.rider_weight_kg
+            or RiderPowerProfile.rider_weight_kg,
+            bike_weight_kg=(
+                request.bike_weight_kg
+                if request.bike_weight_kg is not None
+                else RiderPowerProfile.bike_weight_kg
+            ),
+        )
+
+    def _forecast_points_shifted(
+        self,
+        previous_points: List[ForecastPoint],
+        next_points: List[ForecastPoint],
+        threshold_seconds: int = WIND_REFETCH_THRESHOLD_SECONDS,
+    ) -> bool:
+        if len(previous_points) != len(next_points):
+            return True
+        for previous, next_point in zip(previous_points, next_points):
+            if (
+                abs((next_point.time_utc - previous.time_utc).total_seconds())
+                >= threshold_seconds
+            ):
+                return True
+        return False
+
+    def _build_timing_payload(
+        self,
+        forecast_points: List[ForecastPoint],
+        depart_time: datetime,
+        model: str,
+        warnings: List[str],
+    ) -> dict:
+        if not forecast_points:
+            return {
+                "model": model,
+                "estimated_duration_hours": 0,
+                "estimated_completion_time": depart_time,
+                "warnings": warnings,
+            }
+
+        completion_time = forecast_points[-1].time_utc
+        return {
+            "model": model,
+            "estimated_duration_hours": (completion_time - depart_time).total_seconds()
+            / 3600.0,
+            "estimated_completion_time": completion_time,
+            "warnings": warnings,
+        }
 
     async def _process_wind_segments(
         self,
@@ -715,8 +838,10 @@ class AnalysisService:
                     route_point = RoutePoint(
                         lat=sample.lat,
                         lon=sample.lon,
+                        elevation=sample.elevation_m,
                         distance_m=sample.dist_m,
                         bearing_deg=sample.bearing_deg,
+                        grade_pct=sample.grade_pct,
                         timestamp=None,  # Will be calculated during analysis
                     )
                     route_points.append(route_point)
@@ -767,6 +892,8 @@ class AnalysisService:
                         lon=point.lon,
                         dist_m=point.distance_m,
                         bearing_deg=point.bearing_deg or 0.0,
+                        elevation_m=point.elevation,
+                        grade_pct=point.grade_pct,
                         eta_offset_s=eta_offset_s,
                     )
                     session.add(sample_db)
@@ -873,12 +1000,20 @@ class AnalysisService:
 
         return result
 
-    def _cache_key(self, route_id: str, provider: str, depart_time: datetime) -> str:
+    def _cache_key(self, request: AnalysisRequest) -> str:
         """Normalize cache key to the hour to increase hit rate."""
-        depart_hour = depart_time.replace(
-            minute=0, second=0, microsecond=0, tzinfo=depart_time.tzinfo
+        depart_hour = request.depart_time.replace(
+            minute=0, second=0, microsecond=0, tzinfo=request.depart_time.tzinfo
         )
-        return f"{route_id}:{provider}:{depart_hour.isoformat()}"
+        rider_key = (
+            f"{request.timing_mode}:"
+            f"{request.estimated_duration_hours}:"
+            f"{request.ftp_w_per_kg}:"
+            f"{request.rider_weight_kg}:"
+            f"{request.bike_weight_kg}:"
+            f"{request.use_historical_mode}"
+        )
+        return f"{request.route_id}:{request.provider}:{depart_hour.isoformat()}:{rider_key}"
 
     async def _load_demo_route_into_memory(self) -> bool:
         """Load the demo GPX into in-memory storage with fixed ID if available.

--- a/api/app/storage/db.py
+++ b/api/app/storage/db.py
@@ -43,6 +43,8 @@ class RouteSampleDB(Base):
     lon: Mapped[float] = mapped_column(Float, nullable=False)
     dist_m: Mapped[float] = mapped_column(Float, nullable=False)
     bearing_deg: Mapped[float] = mapped_column(Float, nullable=False)
+    elevation_m: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    grade_pct: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     eta_offset_s: Mapped[int] = mapped_column(Integer, nullable=False)
 
 

--- a/api/migrations/001_initial_schema.sql
+++ b/api/migrations/001_initial_schema.sql
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS route_samples (
     lon FLOAT NOT NULL,
     dist_m FLOAT NOT NULL,
     bearing_deg FLOAT NOT NULL,
+    elevation_m FLOAT,
+    grade_pct FLOAT,
     eta_offset_s INTEGER NOT NULL,
     UNIQUE(route_id, seq)
 );

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -4,7 +4,6 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-
 os.environ.setdefault(
     "DATABASE_URL", "postgresql://postgres:password@localhost:5432/against_wind"
 )

--- a/api/tests/e2e/test_analysis_streaming.py
+++ b/api/tests/e2e/test_analysis_streaming.py
@@ -98,6 +98,10 @@ def test_analyze_stream_emits_partial_results_before_complete(monkeypatch):
     assert [event["total"] for event in partial_events] == [2, 2]
     assert [event["segments"][0]["seq"] for event in partial_events] == [0, 1]
     assert len(complete_events[0]["segments"]) == 2
+    assert (
+        complete_events[0]["segments"][-1]["time_utc"]
+        == complete_events[0]["timing"]["estimated_completion_time"]
+    )
 
 
 def test_analyze_stream_batches_repeated_coordinates_by_time(monkeypatch):

--- a/api/tests/test_time_estimation.py
+++ b/api/tests/test_time_estimation.py
@@ -1,0 +1,109 @@
+from datetime import datetime, timezone
+
+from api.app.domain.models import WindSample
+from api.app.domain.time_estimation import (
+    RiderPowerProfile,
+    build_forecast_points_from_offsets,
+    estimate_route_timing,
+)
+from api.app.geo.gpx import RoutePoint
+
+
+def _route(
+    elevations: list[float | None], spacing_m: float = 1000.0
+) -> list[RoutePoint]:
+    points = []
+    for index, elevation in enumerate(elevations):
+        previous_elevation = elevations[index - 1] if index > 0 else elevation
+        grade_pct = 0.0
+        if index > 0 and elevation is not None and previous_elevation is not None:
+            grade_pct = ((elevation - previous_elevation) / spacing_m) * 100
+
+        points.append(
+            RoutePoint(
+                lat=51.0,
+                lon=-1.0 + index * 0.01,
+                elevation=elevation,
+                distance_m=index * spacing_m,
+                bearing_deg=90.0,
+                grade_pct=grade_pct,
+            )
+        )
+    return points
+
+
+def _wind_sample(u_ms: float, point: RoutePoint, time: datetime) -> WindSample:
+    return WindSample(
+        u_ms=u_ms,
+        v_ms=0.0,
+        height_m=10.0,
+        model_run_id="test",
+        source="test",
+        valid_from=time,
+        valid_to=time,
+        meta={"lat": point.lat, "lon": point.lon},
+    )
+
+
+def test_climb_takes_longer_than_flat_route():
+    profile = RiderPowerProfile(ftp_w_per_kg=2.5, rider_weight_kg=75, bike_weight_kg=10)
+
+    flat = estimate_route_timing(_route([100, 100, 100]), profile)
+    climb = estimate_route_timing(_route([100, 160, 220]), profile)
+
+    assert climb.total_duration_s > flat.total_duration_s
+
+
+def test_tailwind_is_faster_than_headwind():
+    profile = RiderPowerProfile(ftp_w_per_kg=2.5, rider_weight_kg=75, bike_weight_kg=10)
+    points = _route([100, 100, 100])
+    start = datetime(2026, 5, 12, 8, tzinfo=timezone.utc)
+    reference_points = build_forecast_points_from_offsets(
+        points,
+        start,
+        estimate_route_timing(points, profile).eta_offsets_s,
+    )
+
+    tailwind = estimate_route_timing(
+        points,
+        profile,
+        wind_samples=[
+            _wind_sample(6.0, point, reference_points[index].time_utc)
+            for index, point in enumerate(points)
+        ],
+        reference_points=reference_points,
+    )
+    headwind = estimate_route_timing(
+        points,
+        profile,
+        wind_samples=[
+            _wind_sample(-6.0, point, reference_points[index].time_utc)
+            for index, point in enumerate(points)
+        ],
+        reference_points=reference_points,
+    )
+
+    assert tailwind.total_duration_s < headwind.total_duration_s
+
+
+def test_missing_elevation_uses_flat_fallback():
+    estimate = estimate_route_timing(_route([None, None, None]), RiderPowerProfile())
+
+    assert estimate.total_duration_s > 0
+    assert "assuming flat terrain" in " ".join(estimate.warnings)
+
+
+def test_forecast_points_are_monotonic_and_non_linear_on_hilly_route():
+    points = _route([100, 100, 200, 200, 120])
+    start = datetime(2026, 5, 12, 8, tzinfo=timezone.utc)
+    estimate = estimate_route_timing(points, RiderPowerProfile())
+    forecast_points = build_forecast_points_from_offsets(
+        points, start, estimate.eta_offsets_s
+    )
+    segment_seconds = [
+        (forecast_points[i].time_utc - forecast_points[i - 1].time_utc).total_seconds()
+        for i in range(1, len(forecast_points))
+    ]
+
+    assert all(seconds > 0 for seconds in segment_seconds)
+    assert len(set(round(seconds) for seconds in segment_seconds)) > 1

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -112,12 +112,12 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col min-h-screen lg:h-screen">
       <Header />
 
-      <div className="flex flex-1 overflow-hidden min-h-0">
+      <div className="flex flex-1 min-h-0 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
         {/* Left Panel */}
-        <div className="w-96 bg-white dark:bg-gray-800 shadow-lg flex flex-col">
+        <div className="w-full bg-white dark:bg-gray-800 shadow-lg flex flex-col lg:w-96 lg:shrink-0">
           <div className="p-6 border-b">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
@@ -222,7 +222,7 @@ export default function Home() {
         </div>
 
         {/* Map */}
-        <div className="flex-1 min-h-0">
+        <div className="min-h-[420px] flex-1 lg:min-h-0">
           <RouteMap
             routeId={routeId}
             analysisData={analysisData}

--- a/ui/components/ThemeToggle.tsx
+++ b/ui/components/ThemeToggle.tsx
@@ -10,14 +10,6 @@ export function ThemeToggle() {
 
   useEffect(() => setMounted(true), [])
 
-  // Debug logging
-  useEffect(() => {
-    if (mounted) {
-      console.log('Theme debug:', { theme, resolvedTheme })
-      console.log('HTML classes:', document.documentElement.className)
-    }
-  }, [mounted, theme, resolvedTheme])
-
   const getNextTheme = (currentTheme?: string): 'light' | 'dark' | 'system' => {
     switch (currentTheme) {
       case 'light':

--- a/ui/components/analysis/AnalysisPanel.tsx
+++ b/ui/components/analysis/AnalysisPanel.tsx
@@ -38,6 +38,12 @@ export function AnalysisPanel({
     setUseHistoricalMode,
     estimatedDuration,
     setEstimatedDuration,
+    ftpWattsPerKg,
+    setFtpWattsPerKg,
+    riderWeightKg,
+    setRiderWeightKg,
+    bikeWeightKg,
+    setBikeWeightKg,
   } = useRouteMetadata(routeId)
 
   const { isAnalyzing, progress, handleAnalyze } = useAnalysis({
@@ -55,14 +61,17 @@ export function AnalysisPanel({
       timingMode,
       useHistoricalMode,
       estimatedDuration,
+      ftpWattsPerKg,
+      riderWeightKg,
+      bikeWeightKg,
     })
   }
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Wind Analysis</h3>
-        <Button onClick={onReset} variant="secondary">
+        <Button onClick={onReset} variant="secondary" className="w-full sm:w-auto">
           Upload new route
         </Button>
       </div>
@@ -99,11 +108,10 @@ export function AnalysisPanel({
           )}
         </div>
 
-        {/* Estimated Duration (only show when in estimated mode) */}
-        {timingMode === 'estimated' && (
+        {timingMode === 'manual_duration' && (
           <div>
             <label htmlFor="estimated-duration" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Estimated Duration (hours)
+              Manual Duration (hours)
             </label>
             <input
               type="number"
@@ -119,6 +127,64 @@ export function AnalysisPanel({
             {routeMetadata?.total_distance_km && (
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Average speed: {Math.round((routeMetadata.total_distance_km / estimatedDuration) * 10) / 10} km/h
+              </p>
+            )}
+          </div>
+        )}
+
+        {timingMode === 'power' && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label htmlFor="ftp-w-per-kg" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                FTP/kg
+              </label>
+              <input
+                type="number"
+                id="ftp-w-per-kg"
+                value={ftpWattsPerKg}
+                onChange={(e) => setFtpWattsPerKg(parseFloat(e.target.value) || 2.5)}
+                min="0.5"
+                max="10"
+                step="0.1"
+                className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                disabled={isAnalyzing}
+              />
+            </div>
+            <div>
+              <label htmlFor="rider-weight-kg" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Rider kg
+              </label>
+              <input
+                type="number"
+                id="rider-weight-kg"
+                value={riderWeightKg}
+                onChange={(e) => setRiderWeightKg(parseFloat(e.target.value) || 75)}
+                min="30"
+                max="250"
+                step="1"
+                className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                disabled={isAnalyzing}
+              />
+            </div>
+            <div>
+              <label htmlFor="bike-weight-kg" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Bike kg
+              </label>
+              <input
+                type="number"
+                id="bike-weight-kg"
+                value={bikeWeightKg}
+                onChange={(e) => setBikeWeightKg(parseFloat(e.target.value) || 10)}
+                min="0"
+                max="80"
+                step="1"
+                className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                disabled={isAnalyzing}
+              />
+            </div>
+            {routeMetadata?.total_ascent_m !== undefined && (
+              <p className="sm:col-span-3 text-xs text-gray-500 dark:text-gray-400">
+                Climb: {Math.round(routeMetadata.total_ascent_m)} m / Descent: {Math.round(routeMetadata.total_descent_m || 0)} m
               </p>
             )}
           </div>

--- a/ui/components/analysis/TimingModeSelector.tsx
+++ b/ui/components/analysis/TimingModeSelector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ClockIcon, CalendarIcon } from '@heroicons/react/24/outline'
+import { ClockIcon, CalendarIcon, BoltIcon } from '@heroicons/react/24/outline'
 import { format } from 'date-fns'
 import { RouteMetadata, TimingMode } from '@/lib/types/analysis'
 
@@ -31,14 +31,17 @@ export function TimingModeSelector({
           <input
             type="radio"
             name="timing-mode"
-            value="manual"
-            checked={timingMode === 'manual'}
+            value="power"
+            checked={timingMode === 'power'}
             onChange={(e) => setTimingMode(e.target.value as TimingMode)}
             className="mr-2"
             disabled={isAnalyzing}
           />
-          <ClockIcon className="h-4 w-4 mr-1" />
-          <span className="text-sm text-gray-800 dark:text-gray-200">Manual departure time</span>
+          <BoltIcon className="h-4 w-4 mr-1" />
+          <span className="text-sm text-gray-800 dark:text-gray-200">Power + elevation + wind</span>
+          {routeMetadata?.has_elevation === false && (
+            <span className="ml-1 text-xs text-amber-600">flat fallback</span>
+          )}
         </label>
 
         {routeMetadata?.has_timestamps && (
@@ -117,14 +120,14 @@ export function TimingModeSelector({
           <input
             type="radio"
             name="timing-mode"
-            value="estimated"
-            checked={timingMode === 'estimated'}
+            value="manual_duration"
+            checked={timingMode === 'manual_duration'}
             onChange={(e) => setTimingMode(e.target.value as TimingMode)}
             className="mr-2"
             disabled={isAnalyzing}
           />
           <ClockIcon className="h-4 w-4 mr-1" />
-          <span className="text-sm text-gray-800 dark:text-gray-200">Estimated duration</span>
+          <span className="text-sm text-gray-800 dark:text-gray-200">Manual duration</span>
         </label>
       </div>
     </div>

--- a/ui/components/map/MapOverlay.tsx
+++ b/ui/components/map/MapOverlay.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 interface MapOverlayProps {
   isAnalyzing: boolean;
   routeId: string | null;
-  isMapboxTokenSet: boolean;
 }
 
 const Overlay = ({ children }: { children: React.ReactNode }) => (
@@ -12,18 +11,7 @@ const Overlay = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-export function MapOverlay({ isAnalyzing, routeId, isMapboxTokenSet }: MapOverlayProps) {
-  if (!isMapboxTokenSet) {
-    return (
-      <div className="flex-1 flex items-center justify-center bg-gray-100">
-        <div className="text-center">
-          <p className="text-gray-600 mb-2">Map requires Mapbox token</p>
-          <p className="text-sm text-gray-500">Set NEXT_PUBLIC_MAPBOX_TOKEN environment variable</p>
-        </div>
-      </div>
-    );
-  }
-
+export function MapOverlay({ isAnalyzing, routeId }: MapOverlayProps) {
   if (isAnalyzing) {
     return (
       <Overlay>

--- a/ui/components/map/RouteMap.tsx
+++ b/ui/components/map/RouteMap.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
-import Map, { Layer, MapRef, Source } from 'react-map-gl'
+import { KeyboardEvent, MouseEvent, PointerEvent, useMemo, useRef, useState } from 'react'
 import { useRouteData } from '@/lib/hooks/useRouteData'
-import { useMapFitBounds } from '@/lib/hooks/useMapFitBounds'
 import { WindAnalysisLegend } from '@/components/map/WindAnalysisLegend'
 import { WindSegmentTooltip } from '@/components/map/WindSegmentTooltip'
 import { MapOverlay } from '@/components/map/MapOverlay'
@@ -14,136 +12,355 @@ interface RouteMapProps {
   isAnalyzing: boolean
 }
 
-const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || ''
+type Coordinate = [number, number]
 
-const initialViewState = {
-  longitude: -0.1278,
-  latitude: 51.5074,
-  zoom: 10,
+interface ProjectedWindSegment {
+  x: number
+  y: number
+  radius: number
+  color: string
+  label: string
+  data: {
+    windClass: string
+    windSpeed: number
+    windDirection: number
+    confidence: number
+    yawAngle: number
+    seq: number
+  }
 }
 
-const routeLineLayer: any = {
-  id: 'route-line',
-  type: 'line',
-  paint: {
-    'line-color': '#374151',
-    'line-width': 3,
-    'line-opacity': 0.8,
-  },
+interface ScreenPoint {
+  x: number
+  y: number
 }
 
-const windSegmentsLayer: any = {
-  id: 'wind-segments',
-  type: 'circle',
-  paint: {
-    'circle-radius': [
-      'interpolate',
-      ['linear'],
-      ['get', 'windSpeed'],
-      0, 6,
-      5, 10,
-      10, 16,
-      20, 24,
-    ],
-    'circle-color': [
-      'match',
-      ['get', 'windClass'],
-      'head', '#dc2626',
-      'cross', '#d97706',
-      'tail', '#059669',
-      '#6b7280',
-    ],
-    'circle-stroke-width': 2,
-    'circle-stroke-color': '#ffffff',
-    'circle-opacity': 0.9,
-    'circle-stroke-opacity': 1,
-  },
+const VIEWPORT_WIDTH = 1000
+const VIEWPORT_HEIGHT = 700
+const TILE_SIZE = 256
+const TILE_BUFFER = 1
+const MAX_PAN_PX = 700
+
+const extractRouteCoordinates = (geoJson: any): Coordinate[] => {
+  if (!geoJson) return []
+
+  if (geoJson.type === 'FeatureCollection') {
+    return geoJson.features.flatMap((feature: any) => extractRouteCoordinates(feature))
+  }
+
+  if (geoJson.type === 'Feature') {
+    return extractRouteCoordinates(geoJson.geometry)
+  }
+
+  if (geoJson.type === 'LineString') {
+    return geoJson.coordinates
+  }
+
+  if (geoJson.type === 'MultiLineString') {
+    return geoJson.coordinates.flat()
+  }
+
+  return []
+}
+
+const lonToWorldX = (lon: number, zoom: number) => ((lon + 180) / 360) * TILE_SIZE * 2 ** zoom
+
+const latToWorldY = (lat: number, zoom: number) => {
+  const boundedLat = Math.max(-85.05112878, Math.min(85.05112878, lat))
+  const sinLat = Math.sin((boundedLat * Math.PI) / 180)
+
+  return (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) * TILE_SIZE * 2 ** zoom
+}
+
+const project = ([lon, lat]: Coordinate, zoom: number) => ({
+  x: lonToWorldX(lon, zoom),
+  y: latToWorldY(lat, zoom),
+})
+
+const windClassColor = (windClass: string) => {
+  switch (windClass) {
+    case 'head':
+      return '#dc2626'
+    case 'tail':
+      return '#059669'
+    case 'cross':
+      return '#d97706'
+    default:
+      return '#6b7280'
+  }
+}
+
+const windClassLabel = (windClass: string) => {
+  switch (windClass) {
+    case 'head':
+      return 'Headwind'
+    case 'tail':
+      return 'Tailwind'
+    case 'cross':
+      return 'Crosswind'
+    default:
+      return 'Wind'
+  }
+}
+
+const chooseZoom = (coordinates: Coordinate[]) => {
+  for (let zoom = 15; zoom >= 4; zoom -= 1) {
+    const points = coordinates.map(coordinate => project(coordinate, zoom))
+    const xs = points.map(point => point.x)
+    const ys = points.map(point => point.y)
+    const width = Math.max(...xs) - Math.min(...xs)
+    const height = Math.max(...ys) - Math.min(...ys)
+
+    if (width <= VIEWPORT_WIDTH * 0.78 && height <= VIEWPORT_HEIGHT * 0.72) {
+      return zoom
+    }
+  }
+
+  return 4
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
+
+const closestRoutePoint = (point: ScreenPoint, routePoints: ScreenPoint[]) => {
+  if (routePoints.length === 0) return point
+
+  return routePoints.reduce((closest, candidate) => {
+    const candidateDistance = (candidate.x - point.x) ** 2 + (candidate.y - point.y) ** 2
+    const closestDistance = (closest.x - point.x) ** 2 + (closest.y - point.y) ** 2
+
+    return candidateDistance < closestDistance ? candidate : closest
+  }, routePoints[0])
 }
 
 export function RouteMap({ routeId, analysisData, isAnalyzing }: RouteMapProps) {
-  const mapRef = useRef<MapRef>(null)
-  const [viewState, setViewState] = useState(initialViewState)
-  const [mapLoaded, setMapLoaded] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dragStartRef = useRef<{ pointerId: number; x: number; y: number; pan: ScreenPoint } | null>(null)
   const [tooltipInfo, setTooltipInfo] = useState<{ x: number; y: number; data: any } | null>(null)
-
+  const [pan, setPan] = useState<ScreenPoint>({ x: 0, y: 0 })
   const routeGeoJSON = useRouteData(routeId)
-  useMapFitBounds(mapRef, routeGeoJSON, mapLoaded)
 
-  const windSegments = useMemo(() => {
-    if (!analysisData?.segments) return null
-    return {
-      type: 'FeatureCollection' as const,
-      features: analysisData.segments
-        .filter((segment: any) => segment.lat && segment.lon)
-        .map((segment: any) => ({
-          type: 'Feature' as const,
-          properties: {
+  const map = useMemo(() => {
+    const coordinates = extractRouteCoordinates(routeGeoJSON).filter(
+      coordinate => Number.isFinite(coordinate[0]) && Number.isFinite(coordinate[1]),
+    )
+
+    if (coordinates.length === 0) {
+      return null
+    }
+
+    const zoom = chooseZoom(coordinates)
+    const worldPoints = coordinates.map(coordinate => project(coordinate, zoom))
+    const xs = worldPoints.map(point => point.x)
+    const ys = worldPoints.map(point => point.y)
+    const minX = Math.min(...xs)
+    const maxX = Math.max(...xs)
+    const minY = Math.min(...ys)
+    const maxY = Math.max(...ys)
+    const baseTopLeft = {
+      x: (minX + maxX - VIEWPORT_WIDTH) / 2,
+      y: (minY + maxY - VIEWPORT_HEIGHT) / 2,
+    }
+    const topLeft = {
+      x: baseTopLeft.x - pan.x,
+      y: baseTopLeft.y - pan.y,
+    }
+    const maxTile = 2 ** zoom - 1
+    const minTileX = Math.max(0, Math.floor(topLeft.x / TILE_SIZE) - TILE_BUFFER)
+    const maxTileX = Math.min(maxTile, Math.floor((topLeft.x + VIEWPORT_WIDTH) / TILE_SIZE) + TILE_BUFFER)
+    const minTileY = Math.max(0, Math.floor(topLeft.y / TILE_SIZE) - TILE_BUFFER)
+    const maxTileY = Math.min(maxTile, Math.floor((topLeft.y + VIEWPORT_HEIGHT) / TILE_SIZE) + TILE_BUFFER)
+    const tiles = []
+
+    for (let x = minTileX; x <= maxTileX; x += 1) {
+      for (let y = minTileY; y <= maxTileY; y += 1) {
+        tiles.push({
+          key: `${zoom}-${x}-${y}`,
+          src: `https://tile.openstreetmap.org/${zoom}/${x}/${y}.png`,
+          left: x * TILE_SIZE - topLeft.x,
+          top: y * TILE_SIZE - topLeft.y,
+        })
+      }
+    }
+
+    const toViewport = (coordinate: Coordinate) => {
+      const point = project(coordinate, zoom)
+
+      return {
+        x: point.x - topLeft.x,
+        y: point.y - topLeft.y,
+      }
+    }
+    const routePoints = coordinates.map(toViewport)
+    const path = routePoints.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ')
+
+    return { path, routePoints, tiles, toViewport }
+  }, [pan, routeGeoJSON])
+
+  const windSegments = useMemo<ProjectedWindSegment[]>(() => {
+    if (!map || !analysisData?.segments) return []
+
+    return analysisData.segments
+      .filter((segment: any) => Number.isFinite(segment.lon) && Number.isFinite(segment.lat))
+      .map((segment: any) => {
+        const rawPoint = map.toViewport([segment.lon, segment.lat])
+        const point = closestRoutePoint(rawPoint, map.routePoints)
+        const windSpeed = Number(segment.wind_ms1p5m) || 0
+
+        return {
+          x: point.x,
+          y: point.y,
+          radius: Math.min(24, Math.max(7, 7 + windSpeed * 0.9)),
+          color: windClassColor(segment.wind_class),
+          label: windClassLabel(segment.wind_class),
+          data: {
             windClass: segment.wind_class,
-            windSpeed: segment.wind_ms1p5m,
+            windSpeed,
             windDirection: segment.wind_dir_deg10m,
             confidence: segment.confidence,
             yawAngle: segment.yaw_deg,
             seq: segment.seq,
           },
-          geometry: {
-            type: 'Point' as const,
-            coordinates: [segment.lon, segment.lat],
-          },
-        })),
-    }
-  }, [analysisData])
+        }
+      })
+  }, [analysisData, map])
 
-  const handleMapClick = (event: any) => {
-    if (event.features && event.features.length > 0) {
-      const feature = event.features[0]
-      if (feature.properties) {
-        setTooltipInfo({
-          x: event.point.x,
-          y: event.point.y,
-          data: feature.properties,
-        })
-      }
-    } else {
-      setTooltipInfo(null)
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement
+    if (target.closest('[data-map-control="true"]')) return
+
+    dragStartRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      pan,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const dragStart = dragStartRef.current
+    if (!dragStart || dragStart.pointerId !== event.pointerId) return
+
+    setTooltipInfo(null)
+    setPan({
+      x: clamp(dragStart.pan.x + event.clientX - dragStart.x, -MAX_PAN_PX, MAX_PAN_PX),
+      y: clamp(dragStart.pan.y + event.clientY - dragStart.y, -MAX_PAN_PX, MAX_PAN_PX),
+    })
+  }
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (dragStartRef.current?.pointerId === event.pointerId) {
+      dragStartRef.current = null
+      event.currentTarget.releasePointerCapture(event.pointerId)
     }
   }
 
-  if (!MAPBOX_TOKEN) {
-    return <MapOverlay isAnalyzing={false} routeId={null} isMapboxTokenSet={false} />
+  const showTooltip = (
+    event: MouseEvent<SVGCircleElement> | KeyboardEvent<SVGCircleElement>,
+    segment: ProjectedWindSegment,
+  ) => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (!rect) return
+
+    setTooltipInfo({
+      x: (segment.x / VIEWPORT_WIDTH) * rect.width,
+      y: (segment.y / VIEWPORT_HEIGHT) * rect.height,
+      data: segment.data,
+    })
   }
 
   return (
-    <div className="relative h-full w-full">
-      <Map
-        ref={mapRef}
-        {...viewState}
-        onMove={evt => setViewState(evt.viewState)}
-        mapboxAccessToken={MAPBOX_TOKEN}
-        style={{ width: '100%', height: '100%' }}
-        mapStyle="mapbox://styles/mapbox/outdoors-v12"
-        attributionControl={false}
-        onLoad={() => setMapLoaded(true)}
-        interactiveLayerIds={windSegments ? ['wind-segments'] : []}
-        onClick={handleMapClick}
-        cursor={windSegments ? 'pointer' : 'grab'}
-      >
-        {routeGeoJSON && (
-          <Source id="route" type="geojson" data={routeGeoJSON}>
-            <Layer {...routeLineLayer} />
-          </Source>
-        )}
+    <div
+      ref={containerRef}
+      className="relative h-full w-full cursor-grab overflow-hidden bg-slate-100 active:cursor-grabbing dark:bg-gray-900"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+    >
+      {map && (
+        <>
+          <div className="absolute inset-0">
+            {map.tiles.map(tile => (
+              <img
+                key={tile.key}
+                src={tile.src}
+                alt=""
+                className="absolute select-none"
+                draggable={false}
+                style={{
+                  left: `${(tile.left / VIEWPORT_WIDTH) * 100}%`,
+                  top: `${(tile.top / VIEWPORT_HEIGHT) * 100}%`,
+                  width: `${(TILE_SIZE / VIEWPORT_WIDTH) * 100}%`,
+                  height: `${(TILE_SIZE / VIEWPORT_HEIGHT) * 100}%`,
+                }}
+              />
+            ))}
+          </div>
 
-        {windSegments && (
-          <Source id="wind-segments" type="geojson" data={windSegments}>
-            <Layer {...windSegmentsLayer} />
-          </Source>
-        )}
-      </Map>
+          <svg
+            role="img"
+            aria-label="Cycling route map"
+            viewBox={`0 0 ${VIEWPORT_WIDTH} ${VIEWPORT_HEIGHT}`}
+            className="absolute inset-0 h-full w-full"
+            preserveAspectRatio="none"
+            onClick={() => setTooltipInfo(null)}
+          >
+            <path
+              d={map.path}
+              fill="none"
+              stroke="#ffffff"
+              strokeWidth="9"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              opacity="0.95"
+            />
+            <path
+              d={map.path}
+              fill="none"
+              stroke="#374151"
+              strokeWidth="5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+
+            {windSegments.map(segment => (
+              <circle
+                key={`${segment.data.seq}-${segment.x}-${segment.y}`}
+                cx={segment.x}
+                cy={segment.y}
+                r={segment.radius}
+                fill={segment.color}
+                stroke="#ffffff"
+                strokeWidth="4"
+                role="button"
+                tabIndex={0}
+                aria-label={`${segment.label} segment ${segment.data.seq}`}
+                data-map-control="true"
+                className="cursor-pointer transition-opacity hover:opacity-80 focus:outline-none"
+                onPointerDown={event => event.stopPropagation()}
+                onClick={event => {
+                  event.stopPropagation()
+                  showTooltip(event, segment)
+                }}
+                onKeyDown={event => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault()
+                    showTooltip(event, segment)
+                  }
+                }}
+              />
+            ))}
+          </svg>
+        </>
+      )}
+
+      <div className="absolute bottom-1 right-2 z-10 rounded bg-white/80 px-1.5 py-0.5 text-[10px] text-gray-700">
+        &copy; OpenStreetMap contributors
+      </div>
 
       <WindSegmentTooltip tooltipInfo={tooltipInfo} onClose={() => setTooltipInfo(null)} />
-
-      <MapOverlay isAnalyzing={isAnalyzing} routeId={routeId} isMapboxTokenSet={true} />
-
+      <MapOverlay isAnalyzing={isAnalyzing} routeId={routeId} />
       <WindAnalysisLegend analysisData={analysisData} />
     </div>
   )

--- a/ui/lib/hooks/useAnalysis.ts
+++ b/ui/lib/hooks/useAnalysis.ts
@@ -17,6 +17,9 @@ interface PerformAnalysisParams {
   timingMode: TimingMode
   useHistoricalMode: boolean
   estimatedDuration: number
+  ftpWattsPerKg: number
+  riderWeightKg: number
+  bikeWeightKg: number
 }
 
 export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComplete, onAnalysisError }: UseAnalysisProps) {
@@ -29,7 +32,10 @@ export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComp
     provider, 
     timingMode, 
     useHistoricalMode, 
-    estimatedDuration 
+    estimatedDuration,
+    ftpWattsPerKg,
+    riderWeightKg,
+    bikeWeightKg,
   }: PerformAnalysisParams) => {
     onAnalysisStart()
     setIsAnalyzing(true)
@@ -42,12 +48,18 @@ export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComp
         route_id: routeId,
         depart: departISO,
         provider: provider,
-        use_gpx_timestamps: (timingMode === 'gpx_timestamps').toString(),
+        timing_mode: timingMode,
         use_historical_mode: (useHistoricalMode && timingMode === 'gpx_timestamps').toString(),
       })
       
-      if (timingMode === 'estimated') {
+      if (timingMode === 'manual_duration') {
         params.append('estimated_duration_hours', estimatedDuration.toString())
+      }
+
+      if (timingMode === 'power') {
+        params.append('ftp_w_per_kg', ftpWattsPerKg.toString())
+        params.append('rider_weight_kg', riderWeightKg.toString())
+        params.append('bike_weight_kg', bikeWeightKg.toString())
       }
       
       const url = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/analyze?${params.toString()}`

--- a/ui/lib/hooks/useRouteMetadata.ts
+++ b/ui/lib/hooks/useRouteMetadata.ts
@@ -5,7 +5,7 @@ import { RouteMetadata, TimingMode } from '@/lib/types/analysis'
 
 export function useRouteMetadata(routeId: string) {
   const [routeMetadata, setRouteMetadata] = useState<RouteMetadata | null>(null)
-  const [timingMode, setTimingMode] = useState<TimingMode>('manual')
+  const [timingMode, setTimingMode] = useState<TimingMode>('power')
   const [departTime, setDepartTime] = useState(() => {
     const tomorrow = new Date()
     tomorrow.setDate(tomorrow.getDate() + 1)
@@ -14,6 +14,9 @@ export function useRouteMetadata(routeId: string) {
   })
   const [useHistoricalMode, setUseHistoricalMode] = useState<boolean>(false)
   const [estimatedDuration, setEstimatedDuration] = useState<number>(3)
+  const [ftpWattsPerKg, setFtpWattsPerKg] = useState<number>(2.5)
+  const [riderWeightKg, setRiderWeightKg] = useState<number>(75)
+  const [bikeWeightKg, setBikeWeightKg] = useState<number>(10)
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
@@ -51,7 +54,7 @@ export function useRouteMetadata(routeId: string) {
               }
             }
           } else {
-            setTimingMode('manual')
+            setTimingMode('power')
           }
 
           // Set estimated duration from metadata
@@ -82,6 +85,12 @@ export function useRouteMetadata(routeId: string) {
     setUseHistoricalMode,
     estimatedDuration,
     setEstimatedDuration,
+    ftpWattsPerKg,
+    setFtpWattsPerKg,
+    riderWeightKg,
+    setRiderWeightKg,
+    bikeWeightKg,
+    setBikeWeightKg,
     isLoading,
     error,
   }

--- a/ui/lib/types/analysis.ts
+++ b/ui/lib/types/analysis.ts
@@ -1,12 +1,18 @@
 export interface RouteMetadata {
   has_timestamps: boolean;
   timestamp_coverage: number;
+  has_elevation?: boolean;
+  elevation_coverage?: number;
+  total_ascent_m?: number;
+  total_descent_m?: number;
   start_time?: string;
   estimated_duration_hours?: number;
+  eta_model?: string;
+  eta_warnings?: string[];
   total_distance_km?: number;
 }
 
-export type TimingMode = 'manual' | 'gpx_timestamps' | 'estimated';
+export type TimingMode = 'power' | 'manual_duration' | 'gpx_timestamps';
 
 export interface AnalysisProgress {
   stage: string;

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
     NEXT_PUBLIC_MAPBOX_TOKEN: process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '',


### PR DESCRIPTION
## Summary
- add power-based ETA modeling using rider defaults, elevation, and wind-aware segment timing
- persist route elevation and ETA samples through analysis storage
- restore draggable OpenStreetMap route view with aligned wind/data markers

## Tests
- pnpm --config.verify-deps-before-run=false exec tsc --noEmit
- uv run pytest api/tests/test_time_estimation.py api/tests/e2e/test_analysis_streaming.py