### PR TITLE
Add pytest job to GitHub CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: gitleaks
+name: ci
 on: [pull_request, push, workflow_dispatch]
 
 jobs:
@@ -12,3 +12,23 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run pytest
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Rename the workflow to `ci` and keep the existing gitleaks scan
- Add a new `pytest` job on Ubuntu using Python 3.13
- Install locked dependencies with `uv` and run the API test suite in CI

## Testing
- Validated locally with `uv run --python 3.13 pytest`
- Result: 7 tests passed