### PR TITLE
Optimize backend for low-load single-machine deployment

### DIFF
--- a/api/app/core/ttl_cache.py
+++ b/api/app/core/ttl_cache.py
@@ -1,0 +1,32 @@
+import time
+from collections import OrderedDict
+from typing import Any, Optional
+
+
+class TTLCache:
+    """Small process-local TTL/LRU cache for cheap single-machine reuse."""
+
+    def __init__(self, max_items: int, ttl_seconds: int):
+        self.max_items = max_items
+        self.ttl_seconds = ttl_seconds
+        self._items: OrderedDict[str, tuple[float, Any]] = OrderedDict()
+
+    def get(self, key: str) -> Optional[Any]:
+        item = self._items.get(key)
+        if item is None:
+            return None
+
+        expires_at, value = item
+        if expires_at <= time.monotonic():
+            self._items.pop(key, None)
+            return None
+
+        self._items.move_to_end(key)
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        self._items[key] = (time.monotonic() + self.ttl_seconds, value)
+        self._items.move_to_end(key)
+
+        while len(self._items) > self.max_items:
+            self._items.popitem(last=False)

--- a/api/app/geo/gpx.py
+++ b/api/app/geo/gpx.py
@@ -3,6 +3,7 @@ import numpy as np
 from typing import List, Tuple, Optional
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from bisect import bisect_left
 from shapely.geometry import LineString
 from api.app.core.config import get_settings
 import logging
@@ -142,6 +143,7 @@ class GPXProcessor:
             return points
 
         updated_points = []
+        distances = [point.distance_m for point in points]
 
         for i, point in enumerate(points):
             # Find points within the window for bearing calculation
@@ -149,8 +151,8 @@ class GPXProcessor:
             end_dist = point.distance_m + window_m / 2
 
             # Find start and end points for bearing calculation
-            start_idx = self._find_distance_index(points, start_dist)
-            end_idx = self._find_distance_index(points, end_dist)
+            start_idx = self._find_distance_index(points, start_dist, distances)
+            end_idx = self._find_distance_index(points, end_dist, distances)
 
             if start_idx == end_idx:
                 # Fallback to adjacent points
@@ -193,13 +195,16 @@ class GPXProcessor:
 
         sampled_points = [points[0]]  # Always include start point
         total_distance = points[-1].distance_m
+        distances = [point.distance_m for point in points]
 
         # Sample at regular intervals
         current_target = interval_m
 
         while current_target < total_distance:
             # Find the segment containing this distance
-            interpolated_point = self._interpolate_at_distance(points, current_target)
+            interpolated_point = self._interpolate_at_distance(
+                points, current_target, distances
+            )
             if interpolated_point:
                 sampled_points.append(interpolated_point)
 
@@ -219,6 +224,7 @@ class GPXProcessor:
             return points
 
         updated_points = []
+        distances = [point.distance_m for point in points]
 
         for i, point in enumerate(points):
             if point.elevation is None:
@@ -238,8 +244,8 @@ class GPXProcessor:
             start_dist = max(0, point.distance_m - window_m / 2)
             end_dist = point.distance_m + window_m / 2
 
-            start_idx = self._find_distance_index(points, start_dist)
-            end_idx = self._find_distance_index(points, end_dist)
+            start_idx = self._find_distance_index(points, start_dist, distances)
+            end_idx = self._find_distance_index(points, end_dist, distances)
 
             if (
                 start_idx != end_idx
@@ -370,16 +376,32 @@ class GPXProcessor:
         return (bearing_deg + 360) % 360
 
     def _find_distance_index(
-        self, points: List[RoutePoint], target_distance: float
+        self,
+        points: List[RoutePoint],
+        target_distance: float,
+        distances: Optional[List[float]] = None,
     ) -> int:
         """Find index of point closest to target distance."""
-        return min(
-            range(len(points)),
-            key=lambda i: abs(points[i].distance_m - target_distance),
-        )
+        if not points:
+            return 0
+        distances = distances or [point.distance_m for point in points]
+        insert_at = bisect_left(distances, target_distance)
+        if insert_at <= 0:
+            return 0
+        if insert_at >= len(distances):
+            return len(distances) - 1
+
+        before = insert_at - 1
+        after = insert_at
+        if target_distance - distances[before] <= distances[after] - target_distance:
+            return before
+        return after
 
     def _interpolate_at_distance(
-        self, points: List[RoutePoint], distance: float
+        self,
+        points: List[RoutePoint],
+        distance: float,
+        distances: Optional[List[float]] = None,
     ) -> Optional[RoutePoint]:
         """Interpolate a point at the specified distance along the route."""
         if distance <= 0:
@@ -387,47 +409,47 @@ class GPXProcessor:
         if distance >= points[-1].distance_m:
             return points[-1]
 
-        # Find the segment containing this distance
-        for i in range(len(points) - 1):
-            if points[i].distance_m <= distance <= points[i + 1].distance_m:
-                # Linear interpolation
-                p1, p2 = points[i], points[i + 1]
+        distances = distances or [point.distance_m for point in points]
+        right_idx = bisect_left(distances, distance)
+        if right_idx <= 0:
+            return points[0]
+        if right_idx >= len(points):
+            return points[-1]
 
-                if p2.distance_m == p1.distance_m:
-                    return p1
+        p1, p2 = points[right_idx - 1], points[right_idx]
 
-                ratio = (distance - p1.distance_m) / (p2.distance_m - p1.distance_m)
+        if p2.distance_m == p1.distance_m:
+            return p1
 
-                lat = p1.lat + ratio * (p2.lat - p1.lat)
-                lon = p1.lon + ratio * (p2.lon - p1.lon)
-                elevation = None
-                if p1.elevation is not None and p2.elevation is not None:
-                    elevation = p1.elevation + ratio * (p2.elevation - p1.elevation)
+        ratio = (distance - p1.distance_m) / (p2.distance_m - p1.distance_m)
 
-                bearing = p1.bearing_deg if p1.bearing_deg is not None else 0.0
+        lat = p1.lat + ratio * (p2.lat - p1.lat)
+        lon = p1.lon + ratio * (p2.lon - p1.lon)
+        elevation = None
+        if p1.elevation is not None and p2.elevation is not None:
+            elevation = p1.elevation + ratio * (p2.elevation - p1.elevation)
 
-                # Interpolate timestamp if both points have timestamps
-                timestamp = None
-                if p1.timestamp is not None and p2.timestamp is not None:
-                    time_diff = (p2.timestamp - p1.timestamp).total_seconds()
-                    interpolated_seconds = time_diff * ratio
-                    timestamp = p1.timestamp + timedelta(seconds=interpolated_seconds)
-                elif p1.timestamp is not None:
-                    timestamp = p1.timestamp
-                elif p2.timestamp is not None:
-                    timestamp = p2.timestamp
+        bearing = p1.bearing_deg if p1.bearing_deg is not None else 0.0
 
-                return RoutePoint(
-                    lat=lat,
-                    lon=lon,
-                    elevation=elevation,
-                    distance_m=distance,
-                    bearing_deg=bearing,
-                    grade_pct=p1.grade_pct,
-                    timestamp=timestamp,
-                )
+        timestamp = None
+        if p1.timestamp is not None and p2.timestamp is not None:
+            time_diff = (p2.timestamp - p1.timestamp).total_seconds()
+            interpolated_seconds = time_diff * ratio
+            timestamp = p1.timestamp + timedelta(seconds=interpolated_seconds)
+        elif p1.timestamp is not None:
+            timestamp = p1.timestamp
+        elif p2.timestamp is not None:
+            timestamp = p2.timestamp
 
-        return None
+        return RoutePoint(
+            lat=lat,
+            lon=lon,
+            elevation=elevation,
+            distance_m=distance,
+            bearing_deg=bearing,
+            grade_pct=p1.grade_pct,
+            timestamp=timestamp,
+        )
 
     def _calculate_bbox(self, points: List[RoutePoint]) -> List[float]:
         """Calculate bounding box [min_lon, min_lat, max_lon, max_lat]."""

--- a/api/app/providers/open_meteo.py
+++ b/api/app/providers/open_meteo.py
@@ -5,9 +5,13 @@ from datetime import datetime, timezone, timedelta
 from api.app.providers.base import BaseForecastProvider
 from api.app.domain.models import ForecastPoint, WindSample
 from api.app.core.config import get_settings
+from api.app.core.ttl_cache import TTLCache
 import logging
 
 logger = logging.getLogger(__name__)
+_wind_response_cache = TTLCache(
+    max_items=2048, ttl_seconds=get_settings().cache_ttl_seconds
+)
 
 
 class OpenMeteoProvider(BaseForecastProvider):
@@ -73,34 +77,39 @@ class OpenMeteoProvider(BaseForecastProvider):
         # Process in batches to avoid overwhelming the API.
         batch_size = 10  # Fetch 10 points concurrently
 
-        for i in range(0, len(unique_points), batch_size):
-            batch = unique_points[i : i + batch_size]
-            logger.info(
-                f"Fetching batch {i//batch_size + 1}/{(len(unique_points) + batch_size - 1)//batch_size}"
-            )
-
-            tasks = [self._fetch_point_wind(point, model_run_id) for point in batch]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            batch_samples = []
-            for point, result in zip(batch, results):
-                if isinstance(result, Exception):
-                    logger.error(
-                        f"Failed to fetch wind for point {point.lat:.4f}, {point.lon:.4f}: {result}"
-                    )
-                    continue
-
-                batch_samples.extend(result)
-                logger.debug(
-                    f"Fetched {len(result)} samples for point {point.lat:.4f}, {point.lon:.4f}"
+        timeout = httpx.Timeout(max(60.0, float(self.timeout)), connect=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            for i in range(0, len(unique_points), batch_size):
+                batch = unique_points[i : i + batch_size]
+                logger.info(
+                    f"Fetching batch {i//batch_size + 1}/{(len(unique_points) + batch_size - 1)//batch_size}"
                 )
 
-            logger.info(f"Batch returned {len(batch_samples)} wind samples")
-            if batch_samples:
-                yield batch_samples
+                tasks = [
+                    self._fetch_point_wind(point, model_run_id, client)
+                    for point in batch
+                ]
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                batch_samples = []
+                for point, result in zip(batch, results):
+                    if isinstance(result, Exception):
+                        logger.error(
+                            f"Failed to fetch wind for point {point.lat:.4f}, {point.lon:.4f}: {result}"
+                        )
+                        continue
+
+                    batch_samples.extend(result)
+                    logger.debug(
+                        f"Fetched {len(result)} samples for point {point.lat:.4f}, {point.lon:.4f}"
+                    )
+
+                logger.info(f"Batch returned {len(batch_samples)} wind samples")
+                if batch_samples:
+                    yield batch_samples
 
     async def _fetch_point_wind(
-        self, point: ForecastPoint, model_run_id: str
+        self, point: ForecastPoint, model_run_id: str, client: httpx.AsyncClient
     ) -> List[WindSample]:
         now = datetime.now(timezone.utc)
         today = now.date()
@@ -155,16 +164,33 @@ class OpenMeteoProvider(BaseForecastProvider):
                 f"Fetching ERA5 archive for {target_date} at {point.lat:.4f},{point.lon:.4f}"
             )
 
-        # Use a longer timeout for individual requests (default is 30s which might be too short)
-        # Each request should be allowed to complete, with overall batch timeout managed at higher level
-        timeout = httpx.Timeout(60.0, connect=10.0)  # 60s total, 10s connect
+        cache_key = self._wind_cache_key(api_url, params, point)
+        cached_samples = _wind_response_cache.get(cache_key)
+        if cached_samples is not None:
+            return [sample.model_copy(deep=True) for sample in cached_samples]
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(api_url, params=params)
-            resp.raise_for_status()
-            data = resp.json()
+        resp = await client.get(api_url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
 
-        return self._parse_response(data, point, model_run_id)
+        samples = self._parse_response(data, point, model_run_id)
+        _wind_response_cache.set(
+            cache_key, [sample.model_copy(deep=True) for sample in samples]
+        )
+        return samples
+
+    def _wind_cache_key(self, api_url: str, params: dict, point: ForecastPoint) -> str:
+        point_time = point.time_utc
+        if point_time.tzinfo is None:
+            point_time = point_time.replace(tzinfo=timezone.utc)
+        point_hour = point_time.replace(minute=0, second=0, microsecond=0)
+        relevant_params = "&".join(
+            f"{key}={params[key]}" for key in sorted(params) if key != "timezone"
+        )
+        return (
+            f"{api_url}:{round(point.lat, 4)}:{round(point.lon, 4)}:"
+            f"{point_hour.isoformat()}:{relevant_params}"
+        )
 
     def _parse_response(
         self, data: dict, point: ForecastPoint, model_run_id: str

--- a/api/app/services/analyze.py
+++ b/api/app/services/analyze.py
@@ -27,6 +27,7 @@ from api.app.domain.time_estimation import (
 from api.app.geo.gpx import GPXProcessor, RoutePoint
 from api.app.geo.interp import WindInterpolator
 from api.app.providers.open_meteo import get_provider
+from api.app.core.ttl_cache import TTLCache
 from api.app.storage.db import (
     RouteDB,
     RouteSampleDB,
@@ -42,10 +43,10 @@ from sqlalchemy.exc import IntegrityError
 
 logger = logging.getLogger(__name__)
 
-# In-memory cache
+# In-memory storage and bounded process-local analysis cache.
 _route_storage: Dict[str, Route] = {}
 _route_points_storage: Dict[str, List[RoutePoint]] = {}
-_analysis_cache: Dict[str, dict] = {}
+_analysis_cache = TTLCache(max_items=128, ttl_seconds=get_settings().cache_ttl_seconds)
 
 # Fixed demo route ID used by the UI
 DEMO_ROUTE_ID = "demo-glossop-sheffield"
@@ -185,8 +186,8 @@ class AnalysisService:
         try:
             # Attempt to serve from cache first
             cache_key = self._cache_key(request)
-            if cache_key in _analysis_cache:
-                cached = _analysis_cache[cache_key]
+            cached = _analysis_cache.get(cache_key)
+            if cached is not None:
                 yield ProgressEvent(
                     data={
                         "stage": "cache_hit",
@@ -427,7 +428,7 @@ class AnalysisService:
                 "timing": timing_estimate,
             }
             # Cache the completed payload
-            _analysis_cache[cache_key] = payload
+            _analysis_cache.set(cache_key, payload)
             logger.info(f"Stored results for route {request.route_id}")
             # Send a final 100% progress update before completing
             yield ProgressEvent(
@@ -879,13 +880,9 @@ class AnalysisService:
                 )
                 session.add(route_db)
 
-                # Create route sample records (calculate average speed for eta_offset_s)
                 avg_speed_kmh = 25.0  # Default cycling speed
-                for i, point in enumerate(route_points):
-                    eta_offset_s = int(
-                        (point.distance_m / 1000.0 / avg_speed_kmh) * 3600
-                    )
-                    sample_db = RouteSampleDB(
+                sample_rows = [
+                    RouteSampleDB(
                         route_id=route.id,
                         seq=i,
                         lat=point.lat,
@@ -894,9 +891,13 @@ class AnalysisService:
                         bearing_deg=point.bearing_deg or 0.0,
                         elevation_m=point.elevation,
                         grade_pct=point.grade_pct,
-                        eta_offset_s=eta_offset_s,
+                        eta_offset_s=int(
+                            (point.distance_m / 1000.0 / avg_speed_kmh) * 3600
+                        ),
                     )
-                    session.add(sample_db)
+                    for i, point in enumerate(route_points)
+                ]
+                session.add_all(sample_rows)
 
                 try:
                     await session.commit()
@@ -960,9 +961,8 @@ class AnalysisService:
                 )
                 session.add(result_db)
 
-                # Create segment wind records
-                for segment in segments:
-                    segment_db = SegmentWindDB(
+                segment_rows = [
+                    SegmentWindDB(
                         result_id=segment.result_id,
                         seq=segment.seq,
                         time_utc=segment.time_utc,
@@ -974,7 +974,9 @@ class AnalysisService:
                         gust_ms=segment.gust_ms,
                         confidence=segment.confidence,
                     )
-                    session.add(segment_db)
+                    for segment in segments
+                ]
+                session.add_all(segment_rows)
 
                 # Create summary record
                 summary_db = SummaryDB(


### PR DESCRIPTION
## Summary
- Add bounded process-local TTL/LRU cache for analysis results and Open-Meteo wind responses.
- Reuse one shared `httpx.AsyncClient` across wind fetch batches to cut request overhead.
- Speed up GPX route processing by replacing repeated linear distance scans with `bisect`-based lookups.
- Batch database inserts for route samples and segment wind rows.

## Testing
- `uv run --python /Users/yaowenshen/.local/bin/python3.13 pytest`
- `python -m compileall api/app`
- Validation passed: full API test suite and syntax compile check