### PR TITLE
Restore an interactive map view with Mapbox and MapLibre fallback

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import 'mapbox-gl/dist/mapbox-gl.css'
+import 'maplibre-gl/dist/maplibre-gl.css'
 import './globals.css'
 import { ThemeProviders } from '@/components/ThemeProviders'
 

--- a/ui/components/map/RouteMap.tsx
+++ b/ui/components/map/RouteMap.tsx
@@ -1,10 +1,22 @@
 'use client'
 
-import { KeyboardEvent, MouseEvent, PointerEvent, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Map, Satellite } from 'lucide-react'
+import MapboxMap, {
+  Layer as MapboxLayer,
+  NavigationControl as MapboxNavigationControl,
+  Popup as MapboxPopup,
+  Source as MapboxSource,
+} from 'react-map-gl/mapbox'
+import MapLibreMap, {
+  Layer as MapLibreLayer,
+  NavigationControl as MapLibreNavigationControl,
+  Popup as MapLibrePopup,
+  Source as MapLibreSource,
+} from 'react-map-gl/maplibre'
 import { useRouteData } from '@/lib/hooks/useRouteData'
+import { useMapFitBounds } from '@/lib/hooks/useMapFitBounds'
 import { WindAnalysisLegend } from '@/components/map/WindAnalysisLegend'
-import { WindSegmentTooltip } from '@/components/map/WindSegmentTooltip'
 import { MapOverlay } from '@/components/map/MapOverlay'
 
 interface RouteMapProps {
@@ -14,13 +26,20 @@ interface RouteMapProps {
 }
 
 type Coordinate = [number, number]
+type MapLayerId = 'streets' | 'satellite'
 
-interface ProjectedWindSegment {
-  x: number
-  y: number
-  radius: number
-  color: string
+interface BaseMapLayer {
+  id: MapLayerId
   label: string
+  icon: typeof Map
+  attribution: string
+  mapboxStyle: string
+  tiles: string[]
+}
+
+interface SelectedWindSegment {
+  longitude: number
+  latitude: number
   data: {
     windClass: string
     windSpeed: number
@@ -31,44 +50,113 @@ interface ProjectedWindSegment {
   }
 }
 
-interface ScreenPoint {
-  x: number
-  y: number
-}
+const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN
+const MapComponent = (mapboxToken ? MapboxMap : MapLibreMap) as any
+const SourceComponent = (mapboxToken ? MapboxSource : MapLibreSource) as any
+const LayerComponent = (mapboxToken ? MapboxLayer : MapLibreLayer) as any
+const NavigationControlComponent = (
+  mapboxToken ? MapboxNavigationControl : MapLibreNavigationControl
+) as any
+const PopupComponent = (mapboxToken ? MapboxPopup : MapLibrePopup) as any
 
-type MapLayerId = 'streets' | 'satellite'
-
-interface MapLayer {
-  id: MapLayerId
-  label: string
-  icon: typeof Map
-  attribution: string
-  getTileUrl: (zoom: number, x: number, y: number) => string
-}
-
-const VIEWPORT_WIDTH = 1000
-const VIEWPORT_HEIGHT = 700
-const TILE_SIZE = 256
-const TILE_BUFFER = 1
-const MAX_PAN_PX = 700
-
-const MAP_LAYERS: MapLayer[] = [
+const BASE_MAP_LAYERS: BaseMapLayer[] = [
   {
     id: 'streets',
     label: 'Streets',
     icon: Map,
-    attribution: '© OpenStreetMap contributors',
-    getTileUrl: (zoom, x, y) => `https://tile.openstreetmap.org/${zoom}/${x}/${y}.png`,
+    attribution: '&copy; OpenStreetMap contributors',
+    mapboxStyle: 'mapbox://styles/mapbox/outdoors-v12',
+    tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
   },
   {
     id: 'satellite',
     label: 'Satellite',
     icon: Satellite,
-    attribution: 'Tiles © Esri, Maxar, Earthstar Geographics, and the GIS User Community',
-    getTileUrl: (zoom, x, y) =>
-      `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${zoom}/${y}/${x}`,
+    attribution: 'Tiles &copy; Esri, Maxar, Earthstar Geographics, and the GIS User Community',
+    mapboxStyle: 'mapbox://styles/mapbox/satellite-streets-v12',
+    tiles: [
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    ],
   },
 ]
+
+const createRasterStyle = (layer: BaseMapLayer) => ({
+  version: 8,
+  sources: {
+    [layer.id]: {
+      type: 'raster',
+      tiles: layer.tiles,
+      tileSize: 256,
+      attribution: layer.attribution,
+    },
+  },
+  layers: [
+    {
+      id: `${layer.id}-tiles`,
+      type: 'raster',
+      source: layer.id,
+    },
+  ],
+})
+
+const routeHaloLayer: any = {
+  id: 'route-line-halo',
+  type: 'line',
+  paint: {
+    'line-color': '#ffffff',
+    'line-width': 9,
+    'line-opacity': 0.95,
+  },
+  layout: {
+    'line-cap': 'round',
+    'line-join': 'round',
+  },
+}
+
+const routeLayer: any = {
+  id: 'route-line',
+  type: 'line',
+  paint: {
+    'line-color': '#374151',
+    'line-width': 5,
+  },
+  layout: {
+    'line-cap': 'round',
+    'line-join': 'round',
+  },
+}
+
+const windSegmentLayer: any = {
+  id: 'wind-segments',
+  type: 'circle',
+  paint: {
+    'circle-color': [
+      'match',
+      ['get', 'windClass'],
+      'head',
+      '#dc2626',
+      'tail',
+      '#059669',
+      'cross',
+      '#d97706',
+      '#6b7280',
+    ],
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['coalesce', ['to-number', ['get', 'windSpeed']], 0],
+      0,
+      7,
+      8,
+      14,
+      18,
+      24,
+    ],
+    'circle-stroke-color': '#ffffff',
+    'circle-stroke-width': 3,
+    'circle-opacity': 0.95,
+  },
+}
 
 const extractRouteCoordinates = (geoJson: any): Coordinate[] => {
   if (!geoJson) return []
@@ -92,34 +180,13 @@ const extractRouteCoordinates = (geoJson: any): Coordinate[] => {
   return []
 }
 
-const lonToWorldX = (lon: number, zoom: number) => ((lon + 180) / 360) * TILE_SIZE * 2 ** zoom
+const toNumber = (value: unknown, fallback = 0) => {
+  const numberValue = Number(value)
 
-const latToWorldY = (lat: number, zoom: number) => {
-  const boundedLat = Math.max(-85.05112878, Math.min(85.05112878, lat))
-  const sinLat = Math.sin((boundedLat * Math.PI) / 180)
-
-  return (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) * TILE_SIZE * 2 ** zoom
+  return Number.isFinite(numberValue) ? numberValue : fallback
 }
 
-const project = ([lon, lat]: Coordinate, zoom: number) => ({
-  x: lonToWorldX(lon, zoom),
-  y: latToWorldY(lat, zoom),
-})
-
-const windClassColor = (windClass: string) => {
-  switch (windClass) {
-    case 'head':
-      return '#dc2626'
-    case 'tail':
-      return '#059669'
-    case 'cross':
-      return '#d97706'
-    default:
-      return '#6b7280'
-  }
-}
-
-const windClassLabel = (windClass: string) => {
+const formatWindClass = (windClass: string) => {
   switch (windClass) {
     case 'head':
       return 'Headwind'
@@ -132,294 +199,209 @@ const windClassLabel = (windClass: string) => {
   }
 }
 
-const chooseZoom = (coordinates: Coordinate[]) => {
-  for (let zoom = 15; zoom >= 4; zoom -= 1) {
-    const points = coordinates.map(coordinate => project(coordinate, zoom))
-    const xs = points.map(point => point.x)
-    const ys = points.map(point => point.y)
-    const width = Math.max(...xs) - Math.min(...xs)
-    const height = Math.max(...ys) - Math.min(...ys)
-
-    if (width <= VIEWPORT_WIDTH * 0.78 && height <= VIEWPORT_HEIGHT * 0.72) {
-      return zoom
-    }
-  }
-
-  return 4
-}
-
-const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
-
-const closestRoutePoint = (point: ScreenPoint, routePoints: ScreenPoint[]) => {
-  if (routePoints.length === 0) return point
-
-  return routePoints.reduce((closest, candidate) => {
-    const candidateDistance = (candidate.x - point.x) ** 2 + (candidate.y - point.y) ** 2
-    const closestDistance = (closest.x - point.x) ** 2 + (closest.y - point.y) ** 2
-
-    return candidateDistance < closestDistance ? candidate : closest
-  }, routePoints[0])
-}
-
 export function RouteMap({ routeId, analysisData, isAnalyzing }: RouteMapProps) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const dragStartRef = useRef<{ pointerId: number; x: number; y: number; pan: ScreenPoint } | null>(null)
-  const [tooltipInfo, setTooltipInfo] = useState<{ x: number; y: number; data: any } | null>(null)
-  const [pan, setPan] = useState<ScreenPoint>({ x: 0, y: 0 })
+  const mapRef = useRef<any>(null)
+  const [mapLoaded, setMapLoaded] = useState(false)
+  const [cursor, setCursor] = useState('')
   const [mapLayerId, setMapLayerId] = useState<MapLayerId>('streets')
+  const [selectedSegment, setSelectedSegment] = useState<SelectedWindSegment | null>(null)
   const routeGeoJSON = useRouteData(routeId)
-  const mapLayer = MAP_LAYERS.find(layer => layer.id === mapLayerId) ?? MAP_LAYERS[0]
+  const baseMapLayer = BASE_MAP_LAYERS.find(layer => layer.id === mapLayerId) ?? BASE_MAP_LAYERS[0]
 
-  const map = useMemo(() => {
-    const coordinates = extractRouteCoordinates(routeGeoJSON).filter(
-      coordinate => Number.isFinite(coordinate[0]) && Number.isFinite(coordinate[1]),
-    )
+  useMapFitBounds(mapRef, routeGeoJSON, mapLoaded)
+
+  const mapStyle = useMemo(
+    () => (mapboxToken ? baseMapLayer.mapboxStyle : createRasterStyle(baseMapLayer)),
+    [baseMapLayer],
+  )
+
+  const routeSource = useMemo(() => {
+    if (!routeGeoJSON || extractRouteCoordinates(routeGeoJSON).length === 0) return null
+
+    return routeGeoJSON
+  }, [routeGeoJSON])
+
+  const initialViewState = useMemo(() => {
+    const coordinates = extractRouteCoordinates(routeGeoJSON)
 
     if (coordinates.length === 0) {
-      return null
-    }
-
-    const zoom = chooseZoom(coordinates)
-    const worldPoints = coordinates.map(coordinate => project(coordinate, zoom))
-    const xs = worldPoints.map(point => point.x)
-    const ys = worldPoints.map(point => point.y)
-    const minX = Math.min(...xs)
-    const maxX = Math.max(...xs)
-    const minY = Math.min(...ys)
-    const maxY = Math.max(...ys)
-    const baseTopLeft = {
-      x: (minX + maxX - VIEWPORT_WIDTH) / 2,
-      y: (minY + maxY - VIEWPORT_HEIGHT) / 2,
-    }
-    const topLeft = {
-      x: baseTopLeft.x - pan.x,
-      y: baseTopLeft.y - pan.y,
-    }
-    const maxTile = 2 ** zoom - 1
-    const minTileX = Math.max(0, Math.floor(topLeft.x / TILE_SIZE) - TILE_BUFFER)
-    const maxTileX = Math.min(maxTile, Math.floor((topLeft.x + VIEWPORT_WIDTH) / TILE_SIZE) + TILE_BUFFER)
-    const minTileY = Math.max(0, Math.floor(topLeft.y / TILE_SIZE) - TILE_BUFFER)
-    const maxTileY = Math.min(maxTile, Math.floor((topLeft.y + VIEWPORT_HEIGHT) / TILE_SIZE) + TILE_BUFFER)
-    const tiles = []
-
-    for (let x = minTileX; x <= maxTileX; x += 1) {
-      for (let y = minTileY; y <= maxTileY; y += 1) {
-        tiles.push({
-          key: `${mapLayer.id}-${zoom}-${x}-${y}`,
-          src: mapLayer.getTileUrl(zoom, x, y),
-          left: x * TILE_SIZE - topLeft.x,
-          top: y * TILE_SIZE - topLeft.y,
-        })
-      }
-    }
-
-    const toViewport = (coordinate: Coordinate) => {
-      const point = project(coordinate, zoom)
-
       return {
-        x: point.x - topLeft.x,
-        y: point.y - topLeft.y,
+        longitude: -1.75,
+        latitude: 53.4,
+        zoom: 8,
       }
     }
-    const routePoints = coordinates.map(toViewport)
-    const path = routePoints.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ')
 
-    return { path, routePoints, tiles, toViewport }
-  }, [mapLayer, pan, routeGeoJSON])
+    const totals = coordinates.reduce(
+      (acc, coordinate) => ({
+        longitude: acc.longitude + coordinate[0],
+        latitude: acc.latitude + coordinate[1],
+      }),
+      { longitude: 0, latitude: 0 },
+    )
 
-  const windSegments = useMemo<ProjectedWindSegment[]>(() => {
-    if (!map || !analysisData?.segments) return []
+    return {
+      longitude: totals.longitude / coordinates.length,
+      latitude: totals.latitude / coordinates.length,
+      zoom: 9,
+    }
+  }, [routeGeoJSON])
 
-    return analysisData.segments
-      .filter((segment: any) => Number.isFinite(segment.lon) && Number.isFinite(segment.lat))
-      .map((segment: any) => {
-        const rawPoint = map.toViewport([segment.lon, segment.lat])
-        const point = closestRoutePoint(rawPoint, map.routePoints)
-        const windSpeed = Number(segment.wind_ms1p5m) || 0
-
-        return {
-          x: point.x,
-          y: point.y,
-          radius: Math.min(24, Math.max(7, 7 + windSpeed * 0.9)),
-          color: windClassColor(segment.wind_class),
-          label: windClassLabel(segment.wind_class),
-          data: {
-            windClass: segment.wind_class,
-            windSpeed,
-            windDirection: segment.wind_dir_deg10m,
-            confidence: segment.confidence,
-            yawAngle: segment.yaw_deg,
-            seq: segment.seq,
+  const windSegmentsGeoJSON = useMemo(() => {
+    const features =
+      analysisData?.segments
+        ?.filter((segment: any) => Number.isFinite(segment.lon) && Number.isFinite(segment.lat))
+        .map((segment: any) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [segment.lon, segment.lat],
           },
-        }
-      })
-  }, [analysisData, map])
+          properties: {
+            windClass: segment.wind_class,
+            windSpeed: toNumber(segment.wind_ms1p5m),
+            windDirection: toNumber(segment.wind_dir_deg10m),
+            confidence: toNumber(segment.confidence),
+            yawAngle: toNumber(segment.yaw_deg),
+            seq: toNumber(segment.seq),
+          },
+        })) ?? []
 
-  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
-    const target = event.target as HTMLElement
-    if (target.closest('[data-map-control="true"]')) return
-
-    dragStartRef.current = {
-      pointerId: event.pointerId,
-      x: event.clientX,
-      y: event.clientY,
-      pan,
+    return {
+      type: 'FeatureCollection',
+      features,
     }
-    event.currentTarget.setPointerCapture(event.pointerId)
-  }
+  }, [analysisData])
 
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
-    const dragStart = dragStartRef.current
-    if (!dragStart || dragStart.pointerId !== event.pointerId) return
+  const handleClick = (event: any) => {
+    const feature = event.features?.find((clickedFeature: any) => clickedFeature.layer?.id === windSegmentLayer.id)
 
-    setTooltipInfo(null)
-    setPan({
-      x: clamp(dragStart.pan.x + event.clientX - dragStart.x, -MAX_PAN_PX, MAX_PAN_PX),
-      y: clamp(dragStart.pan.y + event.clientY - dragStart.y, -MAX_PAN_PX, MAX_PAN_PX),
-    })
-  }
-
-  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
-    if (dragStartRef.current?.pointerId === event.pointerId) {
-      dragStartRef.current = null
-      event.currentTarget.releasePointerCapture(event.pointerId)
+    if (!feature || feature.geometry.type !== 'Point') {
+      setSelectedSegment(null)
+      return
     }
-  }
 
-  const showTooltip = (
-    event: MouseEvent<SVGCircleElement> | KeyboardEvent<SVGCircleElement>,
-    segment: ProjectedWindSegment,
-  ) => {
-    const rect = containerRef.current?.getBoundingClientRect()
-    if (!rect) return
+    const [longitude, latitude] = feature.geometry.coordinates as Coordinate
+    const properties = feature.properties ?? {}
 
-    setTooltipInfo({
-      x: (segment.x / VIEWPORT_WIDTH) * rect.width,
-      y: (segment.y / VIEWPORT_HEIGHT) * rect.height,
-      data: segment.data,
+    setSelectedSegment({
+      longitude,
+      latitude,
+      data: {
+        windClass: String(properties.windClass ?? 'wind'),
+        windSpeed: toNumber(properties.windSpeed),
+        windDirection: toNumber(properties.windDirection),
+        confidence: toNumber(properties.confidence),
+        yawAngle: toNumber(properties.yawAngle),
+        seq: toNumber(properties.seq),
+      },
     })
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="relative h-full w-full cursor-grab overflow-hidden bg-slate-100 active:cursor-grabbing dark:bg-gray-900"
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerUp}
-    >
-      {map && (
-        <>
-          <div className="absolute inset-0">
-            {map.tiles.map(tile => (
-              <img
-                key={tile.key}
-                src={tile.src}
-                alt=""
-                className="absolute select-none"
-                draggable={false}
-                style={{
-                  left: `${(tile.left / VIEWPORT_WIDTH) * 100}%`,
-                  top: `${(tile.top / VIEWPORT_HEIGHT) * 100}%`,
-                  width: `${(TILE_SIZE / VIEWPORT_WIDTH) * 100}%`,
-                  height: `${(TILE_SIZE / VIEWPORT_HEIGHT) * 100}%`,
-                }}
-              />
-            ))}
-          </div>
+    <div className="relative h-full w-full overflow-hidden bg-slate-100 dark:bg-gray-900">
+      <MapComponent
+        ref={mapRef}
+        initialViewState={initialViewState}
+        {...(mapboxToken ? { mapboxAccessToken: mapboxToken } : {})}
+        mapStyle={mapStyle}
+        style={{ width: '100%', height: '100%' }}
+        cursor={cursor}
+        dragRotate={false}
+        touchPitch={false}
+        interactiveLayerIds={[windSegmentLayer.id]}
+        onLoad={() => setMapLoaded(true)}
+        onClick={handleClick}
+        onMouseEnter={() => setCursor('pointer')}
+        onMouseLeave={() => setCursor('')}
+      >
+        <NavigationControlComponent position="top-right" showCompass={false} />
 
-          <svg
-            role="img"
-            aria-label="Cycling route map"
-            viewBox={`0 0 ${VIEWPORT_WIDTH} ${VIEWPORT_HEIGHT}`}
-            className="absolute inset-0 h-full w-full"
-            preserveAspectRatio="none"
-            onClick={() => setTooltipInfo(null)}
+        {routeSource && (
+          <SourceComponent id="route" type="geojson" data={routeSource}>
+            <LayerComponent {...routeHaloLayer} />
+            <LayerComponent {...routeLayer} />
+          </SourceComponent>
+        )}
+
+        {windSegmentsGeoJSON.features.length > 0 && (
+          <SourceComponent id="wind-segment-points" type="geojson" data={windSegmentsGeoJSON}>
+            <LayerComponent {...windSegmentLayer} />
+          </SourceComponent>
+        )}
+
+        {selectedSegment && (
+          <PopupComponent
+            longitude={selectedSegment.longitude}
+            latitude={selectedSegment.latitude}
+            closeButton
+            closeOnClick={false}
+            anchor="top"
+            offset={12}
+            onClose={() => setSelectedSegment(null)}
           >
-            <path
-              d={map.path}
-              fill="none"
-              stroke="#ffffff"
-              strokeWidth="9"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              opacity="0.95"
-            />
-            <path
-              d={map.path}
-              fill="none"
-              stroke="#374151"
-              strokeWidth="5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
+            <div className="min-w-[190px] text-sm text-gray-900">
+              <h4 className="mb-2 font-semibold">Wind Details</h4>
+              <div className="space-y-1">
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Type:</span>
+                  <span className="font-medium">{formatWindClass(selectedSegment.data.windClass)}</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Speed:</span>
+                  <span className="font-medium">{selectedSegment.data.windSpeed.toFixed(1)} m/s</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Direction:</span>
+                  <span className="font-medium">{selectedSegment.data.windDirection.toFixed(0)}°</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Yaw Angle:</span>
+                  <span className="font-medium">{selectedSegment.data.yawAngle.toFixed(0)}°</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Confidence:</span>
+                  <span className="font-medium">{(selectedSegment.data.confidence * 100).toFixed(0)}%</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-gray-600">Segment:</span>
+                  <span className="font-medium">#{selectedSegment.data.seq}</span>
+                </div>
+              </div>
+            </div>
+          </PopupComponent>
+        )}
+      </MapComponent>
 
-            {windSegments.map(segment => (
-              <circle
-                key={`${segment.data.seq}-${segment.x}-${segment.y}`}
-                cx={segment.x}
-                cy={segment.y}
-                r={segment.radius}
-                fill={segment.color}
-                stroke="#ffffff"
-                strokeWidth="4"
-                role="button"
-                tabIndex={0}
-                aria-label={`${segment.label} segment ${segment.data.seq}`}
-                data-map-control="true"
-                className="cursor-pointer transition-opacity hover:opacity-80 focus:outline-none"
-                onPointerDown={event => event.stopPropagation()}
-                onClick={event => {
-                  event.stopPropagation()
-                  showTooltip(event, segment)
-                }}
-                onKeyDown={event => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    showTooltip(event, segment)
-                  }
-                }}
-              />
-            ))}
-          </svg>
+      <div
+        className="absolute left-3 top-3 z-20 flex rounded-md border border-gray-200 bg-white/95 p-1 shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-900/90"
+        data-map-control="true"
+        aria-label="Map style"
+      >
+        {BASE_MAP_LAYERS.map(layer => {
+          const Icon = layer.icon
+          const isActive = layer.id === mapLayerId
 
-          <div
-            className="absolute right-3 top-3 z-20 flex rounded-md border border-gray-200 bg-white/95 p-1 shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-900/90"
-            data-map-control="true"
-            aria-label="Map style"
-          >
-            {MAP_LAYERS.map(layer => {
-              const Icon = layer.icon
-              const isActive = layer.id === mapLayerId
-
-              return (
-                <button
-                  key={layer.id}
-                  type="button"
-                  className={`inline-flex h-9 items-center gap-1.5 rounded px-2.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:focus:ring-offset-gray-900 ${
-                    isActive
-                      ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
-                      : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'
-                  }`}
-                  aria-pressed={isActive}
-                  title={`Show ${layer.label.toLowerCase()} map`}
-                  onClick={() => setMapLayerId(layer.id)}
-                >
-                  <Icon className="h-4 w-4" aria-hidden="true" />
-                  <span>{layer.label}</span>
-                </button>
-              )
-            })}
-          </div>
-        </>
-      )}
-
-      <div className="absolute bottom-1 right-2 z-10 max-w-[calc(100%-1rem)] rounded bg-white/80 px-1.5 py-0.5 text-[10px] text-gray-700 dark:bg-gray-900/75 dark:text-gray-200">
-        {mapLayer.attribution}
+          return (
+            <button
+              key={layer.id}
+              type="button"
+              className={`inline-flex h-9 items-center gap-1.5 rounded px-2.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:focus:ring-offset-gray-900 ${
+                isActive
+                  ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
+                  : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'
+              }`}
+              aria-pressed={isActive}
+              title={`Show ${layer.label.toLowerCase()} map`}
+              onClick={() => setMapLayerId(layer.id)}
+            >
+              <Icon className="h-4 w-4" aria-hidden="true" />
+              <span>{layer.label}</span>
+            </button>
+          )
+        })}
       </div>
 
-      <WindSegmentTooltip tooltipInfo={tooltipInfo} onClose={() => setTooltipInfo(null)} />
       <MapOverlay isAnalyzing={isAnalyzing} routeId={routeId} />
       <WindAnalysisLegend analysisData={analysisData} />
     </div>

--- a/ui/components/map/RouteMap.tsx
+++ b/ui/components/map/RouteMap.tsx
@@ -8,12 +8,7 @@ import MapboxMap, {
   Popup as MapboxPopup,
   Source as MapboxSource,
 } from 'react-map-gl/mapbox'
-import MapLibreMap, {
-  Layer as MapLibreLayer,
-  NavigationControl as MapLibreNavigationControl,
-  Popup as MapLibrePopup,
-  Source as MapLibreSource,
-} from 'react-map-gl/maplibre'
+import MapLibreMap, { Layer, NavigationControl, Popup, Source } from 'react-map-gl/maplibre'
 import { useRouteData } from '@/lib/hooks/useRouteData'
 import { useMapFitBounds } from '@/lib/hooks/useMapFitBounds'
 import { WindAnalysisLegend } from '@/components/map/WindAnalysisLegend'
@@ -34,6 +29,7 @@ interface BaseMapLayer {
   icon: typeof Map
   attribution: string
   mapboxStyle: string
+  fallbackTiles: string[]
   tiles: string[]
 }
 
@@ -52,12 +48,12 @@ interface SelectedWindSegment {
 
 const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN
 const MapComponent = (mapboxToken ? MapboxMap : MapLibreMap) as any
-const SourceComponent = (mapboxToken ? MapboxSource : MapLibreSource) as any
-const LayerComponent = (mapboxToken ? MapboxLayer : MapLibreLayer) as any
+const SourceComponent = (mapboxToken ? MapboxSource : Source) as any
+const LayerComponent = (mapboxToken ? MapboxLayer : Layer) as any
 const NavigationControlComponent = (
-  mapboxToken ? MapboxNavigationControl : MapLibreNavigationControl
+  mapboxToken ? MapboxNavigationControl : NavigationControl
 ) as any
-const PopupComponent = (mapboxToken ? MapboxPopup : MapLibrePopup) as any
+const PopupComponent = (mapboxToken ? MapboxPopup : Popup) as any
 
 const BASE_MAP_LAYERS: BaseMapLayer[] = [
   {
@@ -66,6 +62,7 @@ const BASE_MAP_LAYERS: BaseMapLayer[] = [
     icon: Map,
     attribution: '&copy; OpenStreetMap contributors',
     mapboxStyle: 'mapbox://styles/mapbox/outdoors-v12',
+    fallbackTiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
     tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
   },
   {
@@ -74,18 +71,21 @@ const BASE_MAP_LAYERS: BaseMapLayer[] = [
     icon: Satellite,
     attribution: 'Tiles &copy; Esri, Maxar, Earthstar Geographics, and the GIS User Community',
     mapboxStyle: 'mapbox://styles/mapbox/satellite-streets-v12',
+    fallbackTiles: [
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    ],
     tiles: [
       'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     ],
   },
 ]
 
-const createRasterStyle = (layer: BaseMapLayer) => ({
+const createRasterStyle = (layer: BaseMapLayer): any => ({
   version: 8,
   sources: {
     [layer.id]: {
       type: 'raster',
-      tiles: layer.tiles,
+      tiles: layer.tiles.length > 0 ? layer.tiles : layer.fallbackTiles,
       tileSize: 256,
       attribution: layer.attribution,
     },
@@ -318,14 +318,14 @@ export function RouteMap({ routeId, analysisData, isAnalyzing }: RouteMapProps) 
         <NavigationControlComponent position="top-right" showCompass={false} />
 
         {routeSource && (
-          <SourceComponent id="route" type="geojson" data={routeSource}>
+          <SourceComponent id="route" type="geojson" data={routeSource as any}>
             <LayerComponent {...routeHaloLayer} />
             <LayerComponent {...routeLayer} />
           </SourceComponent>
         )}
 
         {windSegmentsGeoJSON.features.length > 0 && (
-          <SourceComponent id="wind-segment-points" type="geojson" data={windSegmentsGeoJSON}>
+          <SourceComponent id="wind-segment-points" type="geojson" data={windSegmentsGeoJSON as any}>
             <LayerComponent {...windSegmentLayer} />
           </SourceComponent>
         )}

--- a/ui/lib/hooks/useMapFitBounds.ts
+++ b/ui/lib/hooks/useMapFitBounds.ts
@@ -1,29 +1,60 @@
-import { useEffect } from 'react';
-import type { MapRef } from 'react-map-gl/mapbox';
+import { RefObject, useEffect } from 'react'
+
+type Coordinate = [number, number]
+type MapHandle = {
+  fitBounds: (bounds: [Coordinate, Coordinate], options: { padding: number; duration: number }) => void
+}
+
+const extractCoordinates = (geoJson: any): Coordinate[] => {
+  if (!geoJson) return []
+
+  if (geoJson.type === 'FeatureCollection') {
+    return geoJson.features.flatMap((feature: any) => extractCoordinates(feature))
+  }
+
+  if (geoJson.type === 'Feature') {
+    return extractCoordinates(geoJson.geometry)
+  }
+
+  if (geoJson.type === 'LineString') {
+    return geoJson.coordinates
+  }
+
+  if (geoJson.type === 'MultiLineString') {
+    return geoJson.coordinates.flat()
+  }
+
+  return []
+}
 
 export function useMapFitBounds(
-  mapRef: React.RefObject<MapRef | null>,
+  mapRef: RefObject<MapHandle | null>,
   geoJSON: any,
-  mapLoaded: boolean
+  mapLoaded: boolean,
 ) {
   useEffect(() => {
-    if (!mapLoaded || !geoJSON || !mapRef.current) return;
+    if (!mapLoaded || !mapRef.current) return
 
-    const coordinates = geoJSON.features?.[0]?.geometry?.coordinates;
-    if (!coordinates || coordinates.length === 0) return;
+    const coordinates = extractCoordinates(geoJSON).filter(
+      coordinate => Number.isFinite(coordinate[0]) && Number.isFinite(coordinate[1]),
+    )
+    if (coordinates.length === 0) return
 
-    const bounds = coordinates.reduce(
-      (b: [[number, number], [number, number]], coord: [number, number]) => [
-        [Math.min(b[0][0], coord[0]), Math.min(b[0][1], coord[1])],
-        [Math.max(b[1][0], coord[0]), Math.max(b[1][1], coord[1])],
+    const bounds = coordinates.reduce<[Coordinate, Coordinate]>(
+      (acc: [Coordinate, Coordinate], coordinate) => [
+        [Math.min(acc[0][0], coordinate[0]), Math.min(acc[0][1], coordinate[1])],
+        [Math.max(acc[1][0], coordinate[0]), Math.max(acc[1][1], coordinate[1])],
       ],
-      [[coordinates[0][0], coordinates[0][1]], [coordinates[0][0], coordinates[0][1]]]
-    );
+      [
+        [coordinates[0][0], coordinates[0][1]],
+        [coordinates[0][0], coordinates[0][1]],
+      ],
+    )
 
     try {
-      mapRef.current.fitBounds(bounds, { padding: 50, duration: 1000 });
-    } catch (e) {
-      console.warn('fitBounds failed (possibly before style ready):', e);
+      mapRef.current.fitBounds(bounds, { padding: 70, duration: 800 })
+    } catch (error) {
+      console.warn('fitBounds failed:', error)
     }
-  }, [mapLoaded, geoJSON, mapRef]);
+  }, [mapLoaded, geoJSON, mapRef])
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^1.14.0",
     "mapbox-gl": "^3.23.1",
+    "maplibre-gl": "^5.24.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.14",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       mapbox-gl:
         specifier: ^3.23.1
         version: 3.23.1
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -55,7 +58,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-map-gl:
         specifier: ^8.1.1
-        version: 8.1.1(mapbox-gl@3.23.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 8.1.1(mapbox-gl@3.23.1)(maplibre-gl@5.24.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -455,9 +458,29 @@ packages:
   '@mapbox/vector-tile@2.0.4':
     resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
 
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/geojson-vt@6.1.0':
+    resolution: {integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==}
+
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
     hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@24.8.5':
+    resolution: {integrity: sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.9':
+    resolution: {integrity: sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==}
+
+  '@maplibre/vt-pbf@4.3.0':
+    resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1609,6 +1632,9 @@ packages:
   json-stringify-pretty-compact@3.0.0:
     resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -1667,6 +1693,10 @@ packages:
 
   mapbox-gl@3.23.1:
     resolution: {integrity: sha512-J5M32GunL5KcxvV3ZyLJdr7xtcQ3afAO3VjitLW0v2UVfHjXhq9NO4tkTpn4Dknqwq/pXZG7j1WBfmddLCA26w==}
+
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   martinez-polygon-clipping@0.8.1:
     resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
@@ -2683,6 +2713,14 @@ snapshots:
       '@types/geojson': 7946.0.16
       pbf: 4.0.1
 
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/geojson-vt@6.1.0':
+    dependencies:
+      kdbush: 4.0.2
+
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -2691,6 +2729,29 @@ snapshots:
       minimist: 1.2.8
       rw: 1.3.3
       sort-object: 3.0.3
+
+  '@maplibre/maplibre-gl-style-spec@24.8.5':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.9':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -2985,11 +3046,13 @@ snapshots:
     optionalDependencies:
       mapbox-gl: 3.23.1
 
-  '@vis.gl/react-maplibre@8.1.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@vis.gl/react-maplibre@8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 19.3.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      maplibre-gl: 5.24.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -3950,6 +4013,8 @@ snapshots:
 
   json-stringify-pretty-compact@3.0.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -4026,6 +4091,28 @@ snapshots:
       potpack: 2.1.0
       quickselect: 3.0.0
       supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.8.5
+      '@maplibre/mlt': 1.1.9
+      '@maplibre/vt-pbf': 4.3.0
+      '@types/geojson': 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
       tinyqueue: 3.0.0
 
   martinez-polygon-clipping@0.8.1:
@@ -4278,14 +4365,15 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-map-gl@8.1.1(mapbox-gl@3.23.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-map-gl@8.1.1(mapbox-gl@3.23.1)(maplibre-gl@5.24.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@vis.gl/react-mapbox': 8.1.1(mapbox-gl@3.23.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@vis.gl/react-maplibre': 8.1.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@vis.gl/react-maplibre': 8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       mapbox-gl: 3.23.1
+      maplibre-gl: 5.24.0
 
   react-stately@3.46.0(react@19.2.6):
     dependencies:


### PR DESCRIPTION
**Summary**
- Replaced the static tile-stitching map with a real GL-based map so users can pan and zoom naturally.
- Kept the street and satellite layer toggle, and preserved route/wind overlays on top of the map.
- Added a MapLibre fallback for local use when no Mapbox token is configured.

**Testing**
- `pnpm lint` passed.
- `pnpm build` passed.
- Verified the map in the local browser: route renders, drag/pan works, and the satellite toggle switches correctly.