### PR TITLE
Add configurable wind sample spacing and update route defaults

### DIFF
--- a/api/app/api/routes.py
+++ b/api/app/api/routes.py
@@ -157,6 +157,12 @@ async def analyze_route(
     route_id: str = Query(..., description="Route ID to analyze"),
     depart: str = Query(..., description="Departure time in ISO format"),
     provider: str = Query("open-meteo", description="Forecast provider"),
+    sample_distance_km: float = Query(
+        3.0,
+        ge=1.0,
+        le=10.0,
+        description="Distance between wind forecast samples in kilometres",
+    ),
     timing_mode: Literal["power", "manual_duration", "gpx_timestamps"] = Query(
         "power", description="Timing mode"
     ),
@@ -187,6 +193,7 @@ async def analyze_route(
             route_id=route_id,
             depart_time=depart_time,
             provider=provider,
+            sample_distance_km=sample_distance_km,
             timing_mode=timing_mode,
             estimated_duration_hours=estimated_duration_hours,
             ftp_w_per_kg=ftp_w_per_kg,

--- a/api/app/domain/models.py
+++ b/api/app/domain/models.py
@@ -103,6 +103,7 @@ class AnalysisRequest(BaseModel):
     route_id: str
     depart_time: datetime
     provider: str = "open-meteo"
+    sample_distance_km: float = Field(3.0, ge=1.0, le=10.0)
     timing_mode: Literal["power", "manual_duration", "gpx_timestamps"] = "power"
     estimated_duration_hours: Optional[float] = Field(None, gt=0, le=48)
     ftp_w_per_kg: Optional[float] = Field(None, gt=0, le=10)
@@ -131,6 +132,7 @@ class SegmentWind(BaseModel):
 
     result_id: str
     seq: int
+    distance_m: Optional[float] = None
     time_utc: datetime
     wind_dir_deg10m: float
     wind_ms10m: float

--- a/api/app/domain/time_estimation.py
+++ b/api/app/domain/time_estimation.py
@@ -12,8 +12,8 @@ from api.app.geo.gpx import RoutePoint
 @dataclass(frozen=True)
 class RiderPowerProfile:
     ftp_w_per_kg: float = 2.5
-    rider_weight_kg: float = 75.0
-    bike_weight_kg: float = 10.0
+    rider_weight_kg: float = 65.0
+    bike_weight_kg: float = 9.0
     cda: float = 0.32
     crr: float = 0.005
     air_density_kg_m3: float = 1.225

--- a/api/app/geo/gpx.py
+++ b/api/app/geo/gpx.py
@@ -415,6 +415,8 @@ class GPXProcessor:
             return points[0]
         if right_idx >= len(points):
             return points[-1]
+        if distances[right_idx] == distance:
+            return points[right_idx]
 
         p1, p2 = points[right_idx - 1], points[right_idx]
 

--- a/api/app/services/analyze.py
+++ b/api/app/services/analyze.py
@@ -210,13 +210,19 @@ class AnalysisService:
             route_points = await self._load_route_points(request.route_id)
             if not route_points:
                 raise ValueError(f"Route {request.route_id} not found")
+            route_points = self._resample_route_points(
+                route_points, request.sample_distance_km
+            )
 
             # Step 2: Generate forecast points
             yield ProgressEvent(
                 data={
                     "stage": "generating_forecast_points",
                     "progress": 0.2,
-                    "message": "Generating forecast points...",
+                    "message": (
+                        "Generating forecast points "
+                        f"every {request.sample_distance_km:g} km..."
+                    ),
                 }
             )
 
@@ -293,7 +299,9 @@ class AnalysisService:
                         if total_count
                         else 0.4
                     )
-                    summary_so_far = self._generate_summary(segments)
+                    summary_so_far = self._generate_summary(
+                        segments, request.sample_distance_km
+                    )
 
                     yield PartialResultEvent(
                         data={
@@ -405,7 +413,7 @@ class AnalysisService:
                 }
             )
 
-            summary = self._generate_summary(segments)
+            summary = self._generate_summary(segments, request.sample_distance_km)
 
             # Step 6: Store results
             yield ProgressEvent(
@@ -426,6 +434,7 @@ class AnalysisService:
                 "summary": summary.model_dump(),
                 "map_style_url": self._generate_map_style_url(segments),
                 "timing": timing_estimate,
+                "sample_distance_km": request.sample_distance_km,
             }
             # Cache the completed payload
             _analysis_cache.set(cache_key, payload)
@@ -472,6 +481,24 @@ class AnalysisService:
         return self._generate_power_forecast_points(
             route_points, request.depart_time, request
         )
+
+    def _resample_route_points(
+        self, route_points: List[RoutePoint], sample_distance_km: float
+    ) -> List[RoutePoint]:
+        """Return route points spaced at the requested wind sampling interval."""
+        if not route_points or len(route_points) < 2:
+            return route_points
+
+        sampled_points = self.gpx_processor.sample_route(
+            route_points, interval_km=sample_distance_km
+        )
+        logger.info(
+            "Resampled route from %s to %s points at %.1f km spacing",
+            len(route_points),
+            len(sampled_points),
+            sample_distance_km,
+        )
+        return sampled_points
 
     def _forecast_points_from_gpx_timestamps(
         self,
@@ -725,6 +752,7 @@ class AnalysisService:
             segment = SegmentWind(
                 result_id="",  # Will be set when storing
                 seq=segment_indexes[i] if segment_indexes else i,
+                distance_m=point.distance_m,
                 time_utc=point_time,
                 wind_dir_deg10m=wind_direction,
                 wind_ms10m=wind_speed,
@@ -740,25 +768,46 @@ class AnalysisService:
 
         return segments
 
-    def _generate_summary(self, segments: List[SegmentWind]) -> AnalysisSummary:
+    def _generate_summary(
+        self, segments: List[SegmentWind], sample_distance_km: float = 1.0
+    ) -> AnalysisSummary:
         """Generate analysis summary from segments."""
         if not segments:
             return AnalysisSummary(
                 result_id="", head_pct=0, tail_pct=0, cross_pct=0, longest_head_km=0
             )
 
-        # Calculate percentages
-        total_segments = len(segments)
-        head_count = sum(1 for seg in segments if seg.wind_class == WindClass.HEAD)
-        tail_count = sum(1 for seg in segments if seg.wind_class == WindClass.TAIL)
-        cross_count = sum(1 for seg in segments if seg.wind_class == WindClass.CROSS)
+        segment_spans = self._segment_spans_km(segments, sample_distance_km)
+        total_distance_km = sum(length_km for _, length_km in segment_spans)
 
-        head_pct = (head_count / total_segments) * 100
-        tail_pct = (tail_count / total_segments) * 100
-        cross_pct = (cross_count / total_segments) * 100
+        if total_distance_km <= 0:
+            return AnalysisSummary(
+                result_id="", head_pct=0, tail_pct=0, cross_pct=0, longest_head_km=0
+            )
+
+        # Calculate distance-weighted percentages.
+        head_km = sum(
+            length_km
+            for segment, length_km in segment_spans
+            if segment.wind_class == WindClass.HEAD
+        )
+        tail_km = sum(
+            length_km
+            for segment, length_km in segment_spans
+            if segment.wind_class == WindClass.TAIL
+        )
+        cross_km = sum(
+            length_km
+            for segment, length_km in segment_spans
+            if segment.wind_class == WindClass.CROSS
+        )
+
+        head_pct = (head_km / total_distance_km) * 100
+        tail_pct = (tail_km / total_distance_km) * 100
+        cross_pct = (cross_km / total_distance_km) * 100
 
         # Calculate longest headwind section
-        longest_head_km = self._calculate_longest_headwind(segments)
+        longest_head_km = self._calculate_longest_headwind(segment_spans)
 
         return AnalysisSummary(
             result_id="",
@@ -768,17 +817,55 @@ class AnalysisService:
             longest_head_km=longest_head_km,
         )
 
-    def _calculate_longest_headwind(self, segments: List[SegmentWind]) -> float:
-        """Calculate longest continuous headwind section in km."""
-        longest = 0
-        current = 0
+    def _segment_spans_km(
+        self, segments: List[SegmentWind], sample_distance_km: float
+    ) -> List[tuple[SegmentWind, float]]:
+        """Estimate the route distance represented by each wind sample."""
+        if not segments:
+            return []
 
-        for segment in segments:
+        ordered_segments = sorted(
+            segments,
+            key=lambda segment: (
+                segment.distance_m is None,
+                segment.distance_m if segment.distance_m is not None else segment.seq,
+            ),
+        )
+
+        if len(ordered_segments) == 1:
+            return [(ordered_segments[0], sample_distance_km)]
+
+        spans = []
+        for index, segment in enumerate(ordered_segments):
+            if (
+                segment.distance_m is not None
+                and index < len(ordered_segments) - 1
+                and ordered_segments[index + 1].distance_m is not None
+            ):
+                next_distance_m = ordered_segments[index + 1].distance_m or 0.0
+                span_km = max(next_distance_m - segment.distance_m, 0.0) / 1000.0
+            elif segment.distance_m is not None:
+                span_km = 0.0
+            else:
+                span_km = sample_distance_km
+
+            spans.append((segment, span_km))
+
+        return spans
+
+    def _calculate_longest_headwind(
+        self, segment_spans: List[tuple[SegmentWind, float]]
+    ) -> float:
+        """Calculate longest continuous headwind section in km."""
+        longest = 0.0
+        current = 0.0
+
+        for segment, span_km in segment_spans:
             if segment.wind_class == WindClass.HEAD:
-                current += 1  # Each segment represents ~1km
+                current += span_km
             else:
                 longest = max(longest, current)
-                current = 0
+                current = 0.0
 
         longest = max(longest, current)  # Check final section
         return float(longest)
@@ -1009,6 +1096,7 @@ class AnalysisService:
         )
         rider_key = (
             f"{request.timing_mode}:"
+            f"{request.sample_distance_km}:"
             f"{request.estimated_duration_hours}:"
             f"{request.ftp_w_per_kg}:"
             f"{request.rider_weight_kg}:"

--- a/api/tests/e2e/test_analysis_streaming.py
+++ b/api/tests/e2e/test_analysis_streaming.py
@@ -56,6 +56,15 @@ async def load_route_points(self, route_id):
     ]
 
 
+async def load_resample_route_points(self, route_id):
+    return [
+        RoutePoint(lat=53.0, lon=-1.0, distance_m=0.0, bearing_deg=90.0),
+        RoutePoint(lat=53.01, lon=-1.01, distance_m=1000.0, bearing_deg=90.0),
+        RoutePoint(lat=53.02, lon=-1.02, distance_m=2000.0, bearing_deg=90.0),
+        RoutePoint(lat=53.03, lon=-1.03, distance_m=3000.0, bearing_deg=90.0),
+    ]
+
+
 async def load_repeated_coordinate_route_points(self, route_id):
     return [
         RoutePoint(lat=53.0, lon=-1.0, distance_m=0.0, bearing_deg=90.0),
@@ -102,6 +111,54 @@ def test_analyze_stream_emits_partial_results_before_complete(monkeypatch):
         complete_events[0]["segments"][-1]["time_utc"]
         == complete_events[0]["timing"]["estimated_completion_time"]
     )
+
+
+def test_analyze_stream_respects_sample_distance(monkeypatch):
+    monkeypatch.setattr(AnalysisService, "_load_route_points", load_resample_route_points)
+    monkeypatch.setattr(
+        "api.app.services.analyze.get_provider",
+        lambda provider_name: StreamingForecastProvider(),
+    )
+
+    response = client.get(
+        "/api/v1/analyze",
+        params={
+            "route_id": "streaming-resample-route",
+            "depart": datetime(2026, 5, 12, 10, tzinfo=timezone.utc).isoformat(),
+            "provider": "test-provider",
+            "sample_distance_km": 2,
+        },
+    )
+
+    assert response.status_code == 200
+
+    complete_events = [
+        event_data
+        for event_name, event_data in parse_sse_events(response.text)
+        if event_name == "complete"
+    ]
+
+    assert len(complete_events) == 1
+    assert complete_events[0]["sample_distance_km"] == 2.0
+    assert [segment["distance_m"] for segment in complete_events[0]["segments"]] == [
+        0.0,
+        2000.0,
+        3000.0,
+    ]
+
+
+def test_analyze_rejects_sample_distance_outside_slider_range():
+    response = client.get(
+        "/api/v1/analyze",
+        params={
+            "route_id": "streaming-test-route",
+            "depart": datetime(2026, 5, 12, 10, tzinfo=timezone.utc).isoformat(),
+            "provider": "test-provider",
+            "sample_distance_km": 11,
+        },
+    )
+
+    assert response.status_code == 422
 
 
 def test_analyze_stream_batches_repeated_coordinates_by_time(monkeypatch):

--- a/ui/components/HealthCheckIndicator.tsx
+++ b/ui/components/HealthCheckIndicator.tsx
@@ -36,9 +36,9 @@ const HealthCheckIndicator: React.FC<HealthCheckIndicatorProps> = ({ status }) =
   return (
     <div className="relative flex items-center group">
       <div className={`w-3 h-3 rounded-full ${getStatusColor()}`}></div>
-      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max px-2 py-1 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none">
+      <div className="absolute bottom-full right-0 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 mb-2 w-max max-w-[calc(100vw-2rem)] px-2 py-1 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none">
         {getStatusTooltip()}
-        <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-gray-700 dark:border-t-gray-600"></div>
+        <div className="absolute top-full right-1 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-gray-700 dark:border-t-gray-600"></div>
       </div>
     </div>
   );

--- a/ui/components/analysis/AnalysisPanel.tsx
+++ b/ui/components/analysis/AnalysisPanel.tsx
@@ -27,6 +27,7 @@ export function AnalysisPanel({
   onReset 
 }: AnalysisPanelProps) {
   const [provider, setProvider] = useState('open-meteo')
+  const [sampleDistanceKm, setSampleDistanceKm] = useState(3)
 
   const {
     routeMetadata,
@@ -64,8 +65,25 @@ export function AnalysisPanel({
       ftpWattsPerKg,
       riderWeightKg,
       bikeWeightKg,
+      sampleDistanceKm,
     })
   }
+
+  const updateSampleDistance = (value: string) => {
+    setSampleDistanceKm(parseInt(value, 10))
+  }
+
+  const estimatedSampleCount = routeMetadata?.total_distance_km
+    ? Math.max(2, Math.ceil(routeMetadata.total_distance_km / sampleDistanceKm) + 1)
+    : null
+  const estimatedDurationHours = timingMode === 'manual_duration'
+    ? estimatedDuration
+    : routeMetadata?.estimated_duration_hours ?? estimatedDuration
+  const departDate = new Date(departTime)
+  const estimatedCompletionTime =
+    Number.isFinite(departDate.getTime()) && estimatedDurationHours > 0
+      ? new Date(departDate.getTime() + estimatedDurationHours * 60 * 60 * 1000)
+      : null
 
   return (
     <div className="space-y-4">
@@ -158,7 +176,7 @@ export function AnalysisPanel({
                 type="number"
                 id="rider-weight-kg"
                 value={riderWeightKg}
-                onChange={(e) => setRiderWeightKg(parseFloat(e.target.value) || 75)}
+                onChange={(e) => setRiderWeightKg(parseFloat(e.target.value) || 65)}
                 min="30"
                 max="250"
                 step="1"
@@ -174,7 +192,7 @@ export function AnalysisPanel({
                 type="number"
                 id="bike-weight-kg"
                 value={bikeWeightKg}
-                onChange={(e) => setBikeWeightKg(parseFloat(e.target.value) || 10)}
+                onChange={(e) => setBikeWeightKg(parseFloat(e.target.value) || 9)}
                 min="0"
                 max="80"
                 step="1"
@@ -205,6 +223,38 @@ export function AnalysisPanel({
           </select>
         </div>
 
+        <div>
+          <div className="flex items-center justify-between gap-3 mb-1">
+            <label htmlFor="sample-distance" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Wind sample spacing
+            </label>
+            <span className="shrink-0 text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {sampleDistanceKm} km
+            </span>
+          </div>
+          <input
+            type="range"
+            id="sample-distance"
+            value={sampleDistanceKm}
+            onInput={(e) => updateSampleDistance(e.currentTarget.value)}
+            onChange={(e) => updateSampleDistance(e.currentTarget.value)}
+            min="1"
+            max="10"
+            step="1"
+            className="block w-full accent-blue-600"
+            disabled={isAnalyzing}
+          />
+          <div className="mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>1 km denser</span>
+            <span>10 km faster</span>
+          </div>
+          {estimatedSampleCount !== null && (
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              About {estimatedSampleCount} wind forecast points for this route.
+            </p>
+          )}
+        </div>
+
         <button
           onClick={triggerAnalysis}
           disabled={isAnalyzing}
@@ -229,6 +279,9 @@ export function AnalysisPanel({
       <div className="text-xs text-gray-500 dark:text-gray-400">
         <p>Route ID: {routeId}</p>
         <p>Departure: {format(new Date(departTime), 'PPpp')}</p>
+        {estimatedCompletionTime && (
+          <p>Estimated completion: {format(estimatedCompletionTime, 'PPpp')}</p>
+        )}
       </div>
     </div>
   )

--- a/ui/lib/hooks/useAnalysis.ts
+++ b/ui/lib/hooks/useAnalysis.ts
@@ -20,6 +20,7 @@ interface PerformAnalysisParams {
   ftpWattsPerKg: number
   riderWeightKg: number
   bikeWeightKg: number
+  sampleDistanceKm: number
 }
 
 export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComplete, onAnalysisError }: UseAnalysisProps) {
@@ -36,6 +37,7 @@ export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComp
     ftpWattsPerKg,
     riderWeightKg,
     bikeWeightKg,
+    sampleDistanceKm,
   }: PerformAnalysisParams) => {
     onAnalysisStart()
     setIsAnalyzing(true)
@@ -48,6 +50,7 @@ export function useAnalysis({ onAnalysisStart, onAnalysisPartial, onAnalysisComp
         route_id: routeId,
         depart: departISO,
         provider: provider,
+        sample_distance_km: sampleDistanceKm.toString(),
         timing_mode: timingMode,
         use_historical_mode: (useHistoricalMode && timingMode === 'gpx_timestamps').toString(),
       })

--- a/ui/lib/hooks/useRouteMetadata.ts
+++ b/ui/lib/hooks/useRouteMetadata.ts
@@ -15,8 +15,8 @@ export function useRouteMetadata(routeId: string) {
   const [useHistoricalMode, setUseHistoricalMode] = useState<boolean>(false)
   const [estimatedDuration, setEstimatedDuration] = useState<number>(3)
   const [ftpWattsPerKg, setFtpWattsPerKg] = useState<number>(2.5)
-  const [riderWeightKg, setRiderWeightKg] = useState<number>(75)
-  const [bikeWeightKg, setBikeWeightKg] = useState<number>(10)
+  const [riderWeightKg, setRiderWeightKg] = useState<number>(65)
+  const [bikeWeightKg, setBikeWeightKg] = useState<number>(9)
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 

--- a/ui/lib/types/analysis.ts
+++ b/ui/lib/types/analysis.ts
@@ -10,6 +10,7 @@ export interface RouteMetadata {
   eta_model?: string;
   eta_warnings?: string[];
   total_distance_km?: number;
+  total_points?: number;
 }
 
 export type TimingMode = 'power' | 'manual_duration' | 'gpx_timestamps';


### PR DESCRIPTION
## Summary
- Add a 1-10 km wind sample spacing control and thread it through the API, analysis cache, and timing flow.
- Update the default rider profile to 65 kg rider / 9 kg bike and surface an estimated completion time in the analysis panel.
- Keep the UI responsive and fix the mobile tooltip overflow introduced during the panel update.

## Testing
- `pytest` for the backend analysis and route tests passed.
- `pnpm lint` passed in the UI.
- Verified the updated panel in the local browser, including the new default spacing, rider/bike defaults, completion estimate, and mobile layout behavior.