### PR TITLE
feat: surface actionable wind ride insights

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -51,7 +51,7 @@ def create_app() -> FastAPI:
     # Configure CORS
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.cors_origins,
+        allow_origins=settings.cors_origins_list,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/api/app/services/analyze.py
+++ b/api/app/services/analyze.py
@@ -222,6 +222,7 @@ class AnalysisService:
             forecast_points, timing_estimate = self._build_initial_timing(
                 route_points, request
             )
+            no_wind_timing_estimate = dict(timing_estimate)
 
             # Step 3: Fetch wind data
             yield ProgressEvent(
@@ -394,6 +395,10 @@ class AnalysisService:
                 segments = await self._process_wind_segments(
                     route_points, wind_samples, forecast_points
                 )
+
+            timing_estimate = self._add_no_wind_timing_comparison(
+                timing_estimate, no_wind_timing_estimate, request.timing_mode
+            )
 
             # Step 5: Generate summary
             yield ProgressEvent(
@@ -672,6 +677,35 @@ class AnalysisService:
             "estimated_completion_time": completion_time,
             "warnings": warnings,
         }
+
+    def _add_no_wind_timing_comparison(
+        self, timing_estimate: dict, no_wind_timing_estimate: dict, timing_mode: str
+    ) -> dict:
+        """Attach a calm-air timing comparison when the power model is in use."""
+        if timing_mode != "power":
+            return timing_estimate
+
+        no_wind_duration_hours = no_wind_timing_estimate.get(
+            "estimated_duration_hours"
+        )
+        wind_duration_hours = timing_estimate.get("estimated_duration_hours")
+        if not no_wind_duration_hours or wind_duration_hours is None:
+            return timing_estimate
+
+        delta_seconds = (wind_duration_hours - no_wind_duration_hours) * 3600.0
+        comparison = {
+            "no_wind_estimated_duration_hours": no_wind_duration_hours,
+            "no_wind_estimated_completion_time": no_wind_timing_estimate.get(
+                "estimated_completion_time"
+            ),
+            "wind_duration_delta_s": delta_seconds,
+            "wind_duration_delta_minutes": delta_seconds / 60.0,
+            "wind_duration_delta_pct": (
+                delta_seconds / (no_wind_duration_hours * 3600.0)
+            )
+            * 100.0,
+        }
+        return {**timing_estimate, **comparison}
 
     async def _process_wind_segments(
         self,

--- a/api/tests/test_app_config.py
+++ b/api/tests/test_app_config.py
@@ -1,0 +1,16 @@
+from starlette.middleware.cors import CORSMiddleware
+
+from api.app.core.config import get_settings
+from api.app.main import create_app
+
+
+def test_cors_origins_are_configured_as_parsed_list():
+    app = create_app()
+    cors_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls is CORSMiddleware
+    )
+
+    assert cors_middleware.kwargs["allow_origins"] == get_settings().cors_origins_list
+    assert isinstance(cors_middleware.kwargs["allow_origins"], list)

--- a/api/tests/test_timing_comparison.py
+++ b/api/tests/test_timing_comparison.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta, timezone
+
+from api.app.services.analyze import AnalysisService
+
+
+def test_power_timing_payload_includes_no_wind_delta():
+    service = AnalysisService()
+    depart_time = datetime(2026, 5, 15, 9, tzinfo=timezone.utc)
+    no_wind_timing = {
+        "model": "power",
+        "estimated_duration_hours": 2.0,
+        "estimated_completion_time": depart_time + timedelta(hours=2),
+        "warnings": [],
+    }
+    wind_timing = {
+        "model": "power_with_wind",
+        "estimated_duration_hours": 2.25,
+        "estimated_completion_time": depart_time + timedelta(hours=2, minutes=15),
+        "warnings": [],
+    }
+
+    payload = service._add_no_wind_timing_comparison(
+        wind_timing, no_wind_timing, "power"
+    )
+
+    assert payload["no_wind_estimated_duration_hours"] == 2.0
+    assert payload["no_wind_estimated_completion_time"] == depart_time + timedelta(
+        hours=2
+    )
+    assert payload["wind_duration_delta_s"] == 900
+    assert payload["wind_duration_delta_minutes"] == 15
+    assert payload["wind_duration_delta_pct"] == 12.5
+
+
+def test_non_power_timing_payload_skips_no_wind_delta():
+    service = AnalysisService()
+    timing = {"model": "manual_duration", "estimated_duration_hours": 2.0}
+
+    payload = service._add_no_wind_timing_comparison(timing, timing, "manual_duration")
+
+    assert payload == timing

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -7,6 +7,28 @@ import { AnalysisPanel } from '@/components/analysis/AnalysisPanel'
 import { Header } from '@/components/Header'
 import { loadDemoRoute, cacheAnalysisResults, DEMO_ROUTE_CONFIG } from '@/lib/demo'
 import { Button } from "@/components/ui/button"
+import { calculateWindImpactMetrics, WIND_REFERENCE_SPEED_KMH } from '@/lib/analysisMetrics'
+import { WindActionPlan } from '@/components/analysis/WindActionPlan'
+
+const formatWindSpeed = (speedMs: number) => `${(speedMs * 3.6).toFixed(1)} km/h`
+
+const formatSignedPercent = (value: number) => `${value > 0 ? '+' : ''}${Math.round(value)}%`
+
+const formatHeadwindComponent = (componentMs: number) => {
+  const label = componentMs >= 0 ? 'headwind' : 'tailwind'
+
+  return `${Math.abs(componentMs).toFixed(1)} m/s ${label}`
+}
+
+const formatTimingDelta = (seconds?: number) => {
+  if (!Number.isFinite(seconds)) return null
+
+  const absoluteMinutes = Math.abs(seconds || 0) / 60
+  const roundedMinutes = absoluteMinutes < 1 ? '<1' : Math.round(absoluteMinutes).toString()
+  const verb = (seconds || 0) >= 0 ? 'adds' : 'saves'
+
+  return `Wind ${verb} ${roundedMinutes} min vs no wind`
+}
 
 export default function Home() {
   const [routeId, setRouteId] = useState<string | null>(null)
@@ -111,6 +133,12 @@ export default function Home() {
     }
   }
 
+  const windImpact = calculateWindImpactMetrics(analysisData?.segments)
+  const timingDelta = formatTimingDelta(analysisData?.timing?.wind_duration_delta_s)
+  const aeroLoadTone = (windImpact?.avgAeroLoadDeltaPct || 0) >= 0
+    ? 'text-red-600 dark:text-red-400'
+    : 'text-green-600 dark:text-green-400'
+
   return (
     <div className="flex flex-col min-h-screen lg:h-screen">
       <Header />
@@ -182,6 +210,10 @@ export default function Home() {
           {analysisData && (
             <div className="flex-1 overflow-y-auto p-6 bg-white dark:bg-gray-800">
               <div className="space-y-4">
+                {windImpact && (
+                  <WindActionPlan windImpact={windImpact} timing={analysisData.timing} />
+                )}
+
                 <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
                   <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Wind Summary</h3>
                   <div className="flex flex-col md:flex-row gap-3 md:gap-4 text-sm md:justify-between">
@@ -214,6 +246,56 @@ export default function Home() {
                     <p className="text-red-700 dark:text-red-300">
                       {analysisData.summary.longest_head_km.toFixed(1)} km
                     </p>
+                  </div>
+                )}
+
+                {windImpact && (
+                  <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <h3 className="font-medium text-gray-900 dark:text-gray-100">Speed + Resistance</h3>
+                      <span className="shrink-0 rounded bg-white px-2 py-0.5 text-[11px] text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                        {WIND_REFERENCE_SPEED_KMH} km/h ref
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div className="min-w-0">
+                        <div className="text-lg font-bold leading-none text-gray-900 dark:text-gray-100">
+                          {formatWindSpeed(windImpact.avgWindSpeedMs)}
+                        </div>
+                        <div className="mt-1 text-xs leading-tight text-gray-600 dark:text-gray-300">
+                          Avg rider-height wind
+                        </div>
+                      </div>
+                      <div className="min-w-0">
+                        <div className="text-lg font-bold leading-none text-gray-900 dark:text-gray-100">
+                          {formatWindSpeed(windImpact.maxWindSpeedMs)}
+                        </div>
+                        <div className="mt-1 text-xs leading-tight text-gray-600 dark:text-gray-300">
+                          Strongest segment
+                        </div>
+                      </div>
+                      <div className="min-w-0">
+                        <div className="text-lg font-bold leading-none text-gray-900 dark:text-gray-100">
+                          {formatHeadwindComponent(windImpact.avgHeadwindComponentMs)}
+                        </div>
+                        <div className="mt-1 text-xs leading-tight text-gray-600 dark:text-gray-300">
+                          Net route component
+                        </div>
+                      </div>
+                      <div className="min-w-0">
+                        <div className={`text-lg font-bold leading-none ${aeroLoadTone}`}>
+                          {formatSignedPercent(windImpact.avgAeroLoadDeltaPct)}
+                        </div>
+                        <div className="mt-1 text-xs leading-tight text-gray-600 dark:text-gray-300">
+                          Aero load vs no wind
+                        </div>
+                      </div>
+                    </div>
+                    {timingDelta && (
+                      <div className="mt-3 border-t border-gray-200 pt-3 text-sm font-medium text-gray-800 dark:border-gray-600 dark:text-gray-100">
+                        {timingDelta}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/ui/components/analysis/WindActionPlan.tsx
+++ b/ui/components/analysis/WindActionPlan.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { WindImpactMetrics, WindSectionInsight } from '@/lib/analysisMetrics'
+
+interface WindActionPlanProps {
+  windImpact: WindImpactMetrics
+  timing?: {
+    wind_duration_delta_s?: number
+    wind_duration_delta_pct?: number
+  }
+}
+
+const formatMinutes = (seconds?: number) => {
+  if (!Number.isFinite(seconds)) return null
+
+  const minutes = Math.abs(seconds || 0) / 60
+
+  return minutes < 1 ? '<1 min' : `${Math.round(minutes)} min`
+}
+
+const formatKmRange = (section: WindSectionInsight) => {
+  if (section.lengthKm <= 1) {
+    return `around km ${Math.round(section.startKm)}`
+  }
+
+  return `km ${Math.round(section.startKm)}-${Math.round(section.endKm)}`
+}
+
+const formatPercent = (value: number) => `${value > 0 ? '+' : ''}${Math.round(value)}%`
+
+const formatComponent = (value: number) => {
+  const label = value >= 0 ? 'headwind' : 'tailwind'
+
+  return `${Math.abs(value).toFixed(1)} m/s ${label}`
+}
+
+const buildRideCall = (windImpact: WindImpactMetrics, timing?: WindActionPlanProps['timing']) => {
+  const deltaSeconds = timing?.wind_duration_delta_s
+  const deltaPct = timing?.wind_duration_delta_pct
+  const load = windImpact.avgAeroLoadDeltaPct
+
+  if ((deltaPct || 0) >= 10 || load >= 120) {
+    return {
+      title: 'Harder than calm air',
+      detail: deltaSeconds
+        ? `Expect roughly ${formatMinutes(deltaSeconds)} slower than a no-wind ride.`
+        : `Average aero load is ${formatPercent(load)} versus calm air.`,
+      tone: 'border-red-200 bg-red-50 text-red-950 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-100',
+    }
+  }
+
+  if ((deltaPct || 0) <= -5 || load <= -10) {
+    return {
+      title: 'Wind should help overall',
+      detail: deltaSeconds
+        ? `Expect roughly ${formatMinutes(deltaSeconds)} faster than a no-wind ride.`
+        : `Average aero load is ${formatPercent(load)} versus calm air.`,
+      tone: 'border-green-200 bg-green-50 text-green-950 dark:border-green-900/60 dark:bg-green-950/30 dark:text-green-100',
+    }
+  }
+
+  return {
+    title: 'Manageable wind',
+    detail: deltaSeconds
+      ? `Wind changes the ETA by about ${formatMinutes(deltaSeconds)} versus no wind.`
+      : `Average aero load is ${formatPercent(load)} versus calm air.`,
+    tone: 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100',
+  }
+}
+
+const buildActions = (windImpact: WindImpactMetrics, timing?: WindActionPlanProps['timing']) => {
+  const actions: string[] = []
+  const hardSection = windImpact.hardestSection
+  const reliefSection = windImpact.reliefSection
+  const penaltyPct = timing?.wind_duration_delta_pct || 0
+
+  if (penaltyPct >= 8) {
+    actions.push('If timing is flexible, change the departure time and rerun before committing.')
+  }
+
+  if (hardSection) {
+    actions.push(`Do not chase average speed through ${formatKmRange(hardSection)}; budget effort there.`)
+  }
+
+  if (reliefSection) {
+    actions.push(`Use ${formatKmRange(reliefSection)} to recover or make back time.`)
+  }
+
+  if (windImpact.avgHeadwindComponentMs >= 1) {
+    actions.push('Prioritize aero position or drafting where traffic and route conditions allow.')
+  }
+
+  return actions.slice(0, 3)
+}
+
+const SectionDetail = ({
+  title,
+  section,
+}: {
+  title: string
+  section: WindSectionInsight
+}) => (
+  <div className="rounded-md border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800">
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</h4>
+        <p className="mt-0.5 text-sm text-gray-700 dark:text-gray-300">
+          {formatKmRange(section)} · {section.lengthKm.toFixed(0)} km · {section.dominantWindClass}wind
+        </p>
+      </div>
+      <div className="text-right text-sm font-semibold text-gray-900 dark:text-gray-100">
+        {formatPercent(section.avgAeroLoadDeltaPct)}
+      </div>
+    </div>
+    <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-600 dark:text-gray-300">
+      <span>{formatComponent(section.avgHeadwindComponentMs)}</span>
+      <span className="text-right">peak {formatPercent(section.peakAeroLoadDeltaPct)}</span>
+    </div>
+  </div>
+)
+
+export function WindActionPlan({ windImpact, timing }: WindActionPlanProps) {
+  const rideCall = buildRideCall(windImpact, timing)
+  const actions = buildActions(windImpact, timing)
+
+  return (
+    <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-700">
+      <h3 className="font-medium text-gray-900 dark:text-gray-100">Action Plan</h3>
+
+      <div className={`mt-3 rounded-md border p-3 ${rideCall.tone}`}>
+        <div className="text-sm font-semibold">{rideCall.title}</div>
+        <div className="mt-1 text-sm">{rideCall.detail}</div>
+      </div>
+
+      {actions.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {actions.map(action => (
+            <div key={action} className="text-sm leading-snug text-gray-800 dark:text-gray-100">
+              {action}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 space-y-2">
+        {windImpact.hardestSection && (
+          <SectionDetail title="Hardest wind block" section={windImpact.hardestSection} />
+        )}
+        {windImpact.reliefSection && (
+          <SectionDetail title="Best recovery block" section={windImpact.reliefSection} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/map/WindAnalysisLegend.tsx
+++ b/ui/components/map/WindAnalysisLegend.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { calculateWindImpactMetrics } from '@/lib/analysisMetrics';
 
 interface WindAnalysisLegendProps {
   analysisData: any;
@@ -10,6 +11,7 @@ export function WindAnalysisLegend({ analysisData }: WindAnalysisLegendProps) {
   }
 
   const { summary } = analysisData;
+  const windImpact = calculateWindImpactMetrics(analysisData.segments);
 
   return (
     <div className="absolute bottom-4 left-4 rounded-lg p-4 max-w-xs bg-gray-50 dark:bg-gray-700">
@@ -38,6 +40,18 @@ export function WindAnalysisLegend({ analysisData }: WindAnalysisLegendProps) {
         </div>
       </div>
       <div className="text-xs text-gray-600 dark:text-gray-300 border-t border-gray-200 dark:border-gray-600 pt-2">
+        {windImpact && (
+          <>
+            <p>Avg speed: {(windImpact.avgWindSpeedMs * 3.6).toFixed(1)} km/h</p>
+            <p>Aero load: {windImpact.avgAeroLoadDeltaPct > 0 ? '+' : ''}{Math.round(windImpact.avgAeroLoadDeltaPct)}%</p>
+            {windImpact.hardestSection && (
+              <p>
+                Hardest: km {Math.round(windImpact.hardestSection.startKm)}
+                -{Math.round(windImpact.hardestSection.endKm)}
+              </p>
+            )}
+          </>
+        )}
         <p>Circle size = wind speed</p>
         <p>Click segments for details</p>
       </div>

--- a/ui/components/map/WindSegmentTooltip.tsx
+++ b/ui/components/map/WindSegmentTooltip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { calculateWindVectorImpact, WIND_REFERENCE_SPEED_KMH } from '@/lib/analysisMetrics';
 
 interface TooltipInfo {
   x: number;
@@ -30,6 +31,9 @@ export function WindSegmentTooltip({ tooltipInfo, onClose }: WindSegmentTooltipP
   }
 
   const { x, y, data } = tooltipInfo;
+  const windImpact = calculateWindVectorImpact(Number(data.windSpeed) || 0, Number(data.yawAngle) || 0);
+  const componentLabel = windImpact.headwindComponentMs >= 0 ? 'headwind' : 'tailwind';
+  const aeroLoadPrefix = windImpact.aeroLoadDeltaPct > 0 ? '+' : '';
 
   return (
     <div
@@ -68,6 +72,18 @@ export function WindSegmentTooltip({ tooltipInfo, onClose }: WindSegmentTooltipP
             <span className="text-gray-600 dark:text-gray-300">Yaw Angle:</span>
             <span className="font-medium text-gray-900 dark:text-gray-100">{data.yawAngle?.toFixed(0)}°</span>
           </div>
+          <div className="flex justify-between gap-4">
+            <span className="text-gray-600 dark:text-gray-300">Component:</span>
+            <span className="font-medium text-gray-900 dark:text-gray-100">
+              {Math.abs(windImpact.headwindComponentMs).toFixed(1)} m/s {componentLabel}
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span className="text-gray-600 dark:text-gray-300">Aero Load:</span>
+            <span className="font-medium text-gray-900 dark:text-gray-100">
+              {aeroLoadPrefix}{Math.round(windImpact.aeroLoadDeltaPct)}% vs no wind
+            </span>
+          </div>
           <div className="flex justify-between">
             <span className="text-gray-600 dark:text-gray-300">Confidence:</span>
             <span className="font-medium text-gray-900 dark:text-gray-100">{(data.confidence * 100)?.toFixed(0)}%</span>
@@ -75,6 +91,9 @@ export function WindSegmentTooltip({ tooltipInfo, onClose }: WindSegmentTooltipP
           <div className="flex justify-between">
             <span className="text-gray-600 dark:text-gray-300">Segment:</span>
             <span className="font-medium text-gray-900 dark:text-gray-100">#{data.seq}</span>
+          </div>
+          <div className="pt-1 text-xs text-gray-500 dark:text-gray-400">
+            Aero load estimated at {WIND_REFERENCE_SPEED_KMH} km/h.
           </div>
         </div>
 

--- a/ui/lib/analysisMetrics.ts
+++ b/ui/lib/analysisMetrics.ts
@@ -1,0 +1,244 @@
+export const WIND_REFERENCE_SPEED_KMH = 25
+export const WIND_REFERENCE_SPEED_MS = WIND_REFERENCE_SPEED_KMH / 3.6
+
+export interface SegmentWindLike {
+  seq?: number | string | null
+  wind_class?: string | null
+  wind_ms1p5m?: number | string | null
+  yaw_deg?: number | string | null
+}
+
+export interface WindVectorImpact {
+  headwindComponentMs: number
+  crosswindComponentMs: number
+  apparentWindMs: number
+  aeroLoadDeltaPct: number
+}
+
+export interface WindImpactMetrics {
+  segmentCount: number
+  avgWindSpeedMs: number
+  maxWindSpeedMs: number
+  avgHeadwindComponentMs: number
+  avgAeroLoadDeltaPct: number
+  hardestSection: WindSectionInsight | null
+  reliefSection: WindSectionInsight | null
+}
+
+export interface WindSectionInsight {
+  startKm: number
+  endKm: number
+  lengthKm: number
+  avgWindSpeedMs: number
+  avgHeadwindComponentMs: number
+  avgAeroLoadDeltaPct: number
+  peakAeroLoadDeltaPct: number
+  dominantWindClass: string
+}
+
+interface SegmentImpact extends WindVectorImpact {
+  seq: number
+  windClass: string
+  windSpeedMs: number
+}
+
+const toFiniteNumber = (value: number | string | null | undefined) => {
+  const numberValue = Number(value)
+
+  return Number.isFinite(numberValue) ? numberValue : null
+}
+
+export const calculateWindVectorImpact = (
+  windSpeedMs: number,
+  yawDeg: number,
+  referenceSpeedMs = WIND_REFERENCE_SPEED_MS,
+): WindVectorImpact => {
+  const yawRad = (yawDeg * Math.PI) / 180
+  const windAlongRouteMs = windSpeedMs * Math.cos(yawRad)
+  const crosswindComponentMs = Math.abs(windSpeedMs * Math.sin(yawRad))
+  const apparentWindMs = Math.hypot(referenceSpeedMs - windAlongRouteMs, crosswindComponentMs)
+  const aeroLoadDeltaPct = ((apparentWindMs ** 2) / (referenceSpeedMs ** 2) - 1) * 100
+
+  return {
+    headwindComponentMs: -windAlongRouteMs,
+    crosswindComponentMs,
+    apparentWindMs,
+    aeroLoadDeltaPct,
+  }
+}
+
+export const calculateWindImpactMetrics = (
+  segments: SegmentWindLike[] | null | undefined,
+): WindImpactMetrics | null => {
+  const impacts = (segments || [])
+    .map(segment => {
+      const seq = toFiniteNumber(segment.seq)
+      const windSpeedMs = toFiniteNumber(segment.wind_ms1p5m)
+      const yawDeg = toFiniteNumber(segment.yaw_deg)
+
+      if (seq === null || windSpeedMs === null || yawDeg === null) {
+        return null
+      }
+
+      return {
+        seq,
+        windClass: segment.wind_class || 'wind',
+        windSpeedMs,
+        ...calculateWindVectorImpact(windSpeedMs, yawDeg),
+      }
+    })
+    .filter((impact): impact is SegmentImpact => impact !== null)
+    .sort((a, b) => a.seq - b.seq)
+
+  if (impacts.length === 0) {
+    return null
+  }
+
+  const total = impacts.reduce(
+    (accumulator, impact) => ({
+      windSpeedMs: accumulator.windSpeedMs + impact.windSpeedMs,
+      headwindComponentMs: accumulator.headwindComponentMs + impact.headwindComponentMs,
+      aeroLoadDeltaPct: accumulator.aeroLoadDeltaPct + impact.aeroLoadDeltaPct,
+    }),
+    { windSpeedMs: 0, headwindComponentMs: 0, aeroLoadDeltaPct: 0 },
+  )
+
+  const avgAeroLoadDeltaPct = total.aeroLoadDeltaPct / impacts.length
+  const hardSectionThreshold = Math.max(75, avgAeroLoadDeltaPct * 1.15)
+
+  return {
+    segmentCount: impacts.length,
+    avgWindSpeedMs: total.windSpeedMs / impacts.length,
+    maxWindSpeedMs: Math.max(...impacts.map(impact => impact.windSpeedMs)),
+    avgHeadwindComponentMs: total.headwindComponentMs / impacts.length,
+    avgAeroLoadDeltaPct,
+    hardestSection: findBestSection(
+      impacts,
+      impact => impact.aeroLoadDeltaPct >= hardSectionThreshold,
+      'hardest',
+    ) || findBestWindow(impacts, 'hardest', 5),
+    reliefSection: findBestSection(
+      impacts,
+      impact => impact.aeroLoadDeltaPct <= -10 || impact.headwindComponentMs <= -0.75,
+      'relief',
+    ),
+  }
+}
+
+const findBestSection = (
+  impacts: SegmentImpact[],
+  includesImpact: (impact: SegmentImpact) => boolean,
+  mode: 'hardest' | 'relief',
+): WindSectionInsight | null => {
+  const sections: SegmentImpact[][] = []
+  let currentSection: SegmentImpact[] = []
+
+  for (const impact of impacts) {
+    const previousImpact = currentSection[currentSection.length - 1]
+    const isContiguous = !previousImpact || impact.seq === previousImpact.seq + 1
+
+    if (includesImpact(impact) && isContiguous) {
+      currentSection.push(impact)
+      continue
+    }
+
+    if (currentSection.length > 0) {
+      sections.push(currentSection)
+    }
+    currentSection = includesImpact(impact) ? [impact] : []
+  }
+
+  if (currentSection.length > 0) {
+    sections.push(currentSection)
+  }
+
+  if (sections.length === 0) {
+    return null
+  }
+
+  const rankedSections = sections
+    .map(section => ({
+      section,
+      score: section.reduce((total, impact) => {
+        const load = mode === 'hardest'
+          ? Math.max(0, impact.aeroLoadDeltaPct)
+          : Math.max(0, -impact.aeroLoadDeltaPct)
+
+        return total + load
+      }, 0),
+    }))
+    .sort((a, b) => b.score - a.score)
+
+  return summarizeSection(rankedSections[0].section)
+}
+
+const summarizeSection = (section: SegmentImpact[]): WindSectionInsight => {
+  const totals = section.reduce(
+    (accumulator, impact) => ({
+      windSpeedMs: accumulator.windSpeedMs + impact.windSpeedMs,
+      headwindComponentMs: accumulator.headwindComponentMs + impact.headwindComponentMs,
+      aeroLoadDeltaPct: accumulator.aeroLoadDeltaPct + impact.aeroLoadDeltaPct,
+    }),
+    { windSpeedMs: 0, headwindComponentMs: 0, aeroLoadDeltaPct: 0 },
+  )
+  const windClassCounts = section.reduce<Record<string, number>>((counts, impact) => {
+    counts[impact.windClass] = (counts[impact.windClass] || 0) + 1
+
+    return counts
+  }, {})
+  const dominantWindClass = Object.entries(windClassCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || 'wind'
+
+  return {
+    startKm: section[0].seq,
+    endKm: section[section.length - 1].seq + 1,
+    lengthKm: section.length,
+    avgWindSpeedMs: totals.windSpeedMs / section.length,
+    avgHeadwindComponentMs: totals.headwindComponentMs / section.length,
+    avgAeroLoadDeltaPct: totals.aeroLoadDeltaPct / section.length,
+    peakAeroLoadDeltaPct: section.reduce((peak, impact) => (
+      Math.abs(impact.aeroLoadDeltaPct) > Math.abs(peak) ? impact.aeroLoadDeltaPct : peak
+    ), section[0].aeroLoadDeltaPct),
+    dominantWindClass,
+  }
+}
+
+const findBestWindow = (
+  impacts: SegmentImpact[],
+  mode: 'hardest' | 'relief',
+  targetLengthKm: number,
+): WindSectionInsight | null => {
+  if (impacts.length === 0) {
+    return null
+  }
+
+  const windowLength = Math.min(targetLengthKm, impacts.length)
+  const windows: SegmentImpact[][] = []
+
+  for (let index = 0; index <= impacts.length - windowLength; index += 1) {
+    const window = impacts.slice(index, index + windowLength)
+    const isContiguous = window.every((impact, windowIndex) => (
+      windowIndex === 0 || impact.seq === window[windowIndex - 1].seq + 1
+    ))
+
+    if (isContiguous) {
+      windows.push(window)
+    }
+  }
+
+  if (windows.length === 0) {
+    return summarizeSection(impacts.slice(0, windowLength))
+  }
+
+  const rankedWindows = windows
+    .map(window => ({
+      window,
+      score: window.reduce((total, impact) => {
+        const load = mode === 'hardest' ? impact.aeroLoadDeltaPct : -impact.aeroLoadDeltaPct
+
+        return total + load
+      }, 0),
+    }))
+    .sort((a, b) => b.score - a.score)
+
+  return summarizeSection(rankedWindows[0].window)
+}


### PR DESCRIPTION
## Summary
- Add an action-oriented wind analysis card that turns raw wind data into rider decisions: ride severity, ETA impact vs no wind, when to rerun for a better departure, and where to budget effort or recover.
- Expand supporting detail across the map legend and segment tooltip with range-level and segment-level wind load context.
- Fix API CORS configuration to use the parsed origin list so the frontend can fetch metadata and analysis reliably.

## Testing
- Added backend coverage for the calm-air timing comparison and CORS configuration.
- Ran the targeted Python test suite for timing, streaming analysis, and app config.
- Built the Next.js UI successfully and validated the updated flow in-browser on desktop and mobile with Playwright.